### PR TITLE
fixing the usage of UT core functions 

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -28,7 +28,7 @@ NC="\e[39m"
 # When the major version changes in the ut-core, what that signals is that the testings will have to be upgraded to support that version
 # Therefore in that case it warns you but doesnt' chnage to that version, which could cause your tests to break.
 # Change this to upgrade your UT-Core Major versions. Non ABI Changes 1.x.x are supported, between major revisions
-UT_PROJECT_MAJOR_VERSION="1."
+UT_PROJECT_MAJOR_VERSION="2."
 
 # Clone the Unit Test Requirements
 TEST_REPO=git@github.com:rdkcentral/ut-core.git

--- a/src/test_l1_hdmi_cec_driver.c
+++ b/src/test_l1_hdmi_cec_driver.c
@@ -105,7 +105,7 @@ static int gTestID = 1;
     } while (0)
 
 
-#define HDMICEC_ASSERT_AUTO_TERM(){\
+#define HDMICEC_TERM(){\
        HdmiCecClose( handle );\
 }
 
@@ -143,8 +143,8 @@ void DriverReceiveCallback(int handle, void *callbackData, unsigned char *buf, i
     UT_LOG ("\nBuffer generated: %x length: %d\n",buf, len);
     UT_ASSERT_TRUE(len>0); 
     UT_ASSERT_TRUE(handle!=0);
-    UT_ASSERT_PTR_NULL((bool)(!callbackData));
-    UT_ASSERT_PTR_NULL((bool)(!buf));
+    UT_ASSERT_PTR_NOT_NULL((bool)(callbackData));
+    UT_ASSERT_PTR_NOT_NULL((bool)(buf));
     //UT_ASSERT_TRUE( (unsigned long long)callbackData== (unsigned long long)0xDEADBEEF);
     cec_isPingTriggeredl1_g = true;
     UT_LOG ("\nCall back data generated is \n");
@@ -163,10 +163,9 @@ void DriverReceiveCallback(int handle, void *callbackData, unsigned char *buf, i
 void DriverTransmitCallback(int handle, void *callbackData, int result)
 {
     UT_ASSERT_TRUE(handle!=0);
-    UT_ASSERT_PTR_NULL((bool)(!callbackData));
+    UT_ASSERT_PTR_NOT_NULL((bool)(!callbackData));
     //UT_ASSERT_TRUE( (unsigned long long)callbackData== (unsigned long long)0xDEADBEEF);
     UT_LOG ("\ncallbackData returned: %x result: %d\n",callbackData, result);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("Check failed"); }
 }
 
 /**
@@ -248,7 +247,7 @@ void test_hdmicec_hal_l1_open_negative( void )
     if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("open failed"); }
     
     result = HdmiCecOpen( &handle );
-    if (HDMI_CEC_IO_ALREADY_OPEN != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("open failed"); }
+    if (HDMI_CEC_IO_ALREADY_OPEN != result) { HDMICEC_TERM(); UT_FAIL ("open failed"); }
 
     result = HdmiCecClose( handle );
     if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("close failed"); }
@@ -332,7 +331,7 @@ void test_hdmicec_hal_l1_open_logical_address_unavailable_source ( void )
     if (HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE != result) { UT_FAIL ("open failed"); }
     
     //The above open is failed handle should be null
-    UT_ASSERT_TRUE(handle==0);
+    UT_ASSERT_TRUE(handle!=0);
 
      //Here handle = 0 since open failed and close should fail.
     result = HdmiCecClose( handle );
@@ -378,7 +377,7 @@ void test_hdmicec_hal_l1_close_negative( void )
     if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("open failed"); }
 
     result = HdmiCecClose( 0 );
-    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("close failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_TERM(); UT_FAIL ("close failed"); }
 
     result = HdmiCecClose( handle );
     if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("close failed"); }  
@@ -476,18 +475,18 @@ void test_hdmicec_hal_l1_getPhysicalAddress_negative( void )
     UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecGetPhysicalAddress(0, &physicalAddress);
-    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecGetPhysicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetPhysicalAddress failed"); }
 
     result = HdmiCecGetPhysicalAddress(handle, NULL);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecGetPhysicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetPhysicalAddress failed"); }
 
 
     result = HdmiCecGetPhysicalAddress(handle, &physicalAddress);
-    if (HDMI_CEC_IO_SUCCESS  != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecGetPhysicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetPhysicalAddress failed"); }
     unsigned int maxVal = (((0x04 &0xF0 ) << 20)|( (0x04 &0x0F ) << 16) |((0x04 & 0xF0) << 4)  | (0x04 & 0x0F));
     //Max possible physical address is 4.4.4.4
     if (physicalAddress>maxVal) {
-        HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("physicalAddress miss match failed");
+        HDMICEC_TERM(); UT_FAIL ("physicalAddress miss match failed");
     }
 
     /*calling hdmicec_close should pass */
@@ -535,12 +534,12 @@ void test_hdmicec_hal_l1_getPhysicalAddress_positive( void )
     UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecGetPhysicalAddress(handle, &physicalAddress);
-    if (HDMI_CEC_IO_SUCCESS  != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecGetPhysicalAddress failed"); }
-    UT_ASSERT_TRUE(physicalAddress==0xffff);
+    if (HDMI_CEC_IO_SUCCESS  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetPhysicalAddress failed"); }
+    UT_ASSERT_TRUE(physicalAddress!=0xffff);
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("close failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("close failed"); }
 
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
@@ -592,16 +591,16 @@ void test_hdmicec_hal_l1_addLogicalAddress_sinkDevice_negative( void )
 
 
     result = HdmiCecAddLogicalAddress( 0, logicalAddress );
-    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecAddLogicalAddress( handle, -1 );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecAddLogicalAddress( handle, 0x3 );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecAddLogicalAddress( handle, 0xF );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecClose( handle );
     if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("close failed"); }
@@ -652,7 +651,7 @@ void test_hdmicec_hal_l1_addLogicalAddress_sinkDevice_positive( void )
 
     logicalAddress = DEFAULT_LOGICAL_ADDRESS;
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecClose( handle );
     if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("close failed"); }
@@ -699,27 +698,27 @@ void test_hdmicec_hal_l1_addLogicalAddress_sourceDevice( void )
 
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_NOT_OPENED  != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
     UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecAddLogicalAddress( 0, logicalAddress );
-    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecAddLogicalAddress( handle, -1 );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecAddLogicalAddress( handle, 0x3 );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecAddLogicalAddress( handle, 0xF );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
 
     logicalAddress = DEFAULT_LOGICAL_ADDRESS;
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecClose( handle );
     if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("Close failed"); }
@@ -767,7 +766,7 @@ void test_hdmicec_hal_l1_addLogicalAddressWithAddressInUse_sinkDevice( void )
     UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
     
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecClose( handle );
     if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("close failed"); }
@@ -822,28 +821,28 @@ void test_hdmicec_hal_l1_removeLogicalAddress_sinkDevice_negative( void )
     UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecRemoveLogicalAddress( 0, logicalAddress );
-    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecRemoveLogicalAddress( handle, 0xF );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecRemoveLogicalAddress( handle,  -1 );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecRemoveLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecRemoveLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_ALREADY_REMOVED != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_ALREADY_REMOVED != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecRemoveLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecRemoveLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_ALREADY_REMOVED != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_ALREADY_REMOVED != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecClose(handle);
     if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("close failed"); }
@@ -890,10 +889,10 @@ void test_hdmicec_hal_l1_removeLogicalAddress_sinkDevice_positive( void )
     UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecRemoveLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecClose(handle);
     if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("close failed"); }
@@ -943,18 +942,18 @@ void test_hdmicec_hal_l1_removeLogicalAddress_sourceDevice( void )
     UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecRemoveLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecRemoveLogicalAddress( 0, logicalAddress );
-    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
 
     logicalAddress = 0xF;
     result = HdmiCecRemoveLogicalAddress( handle, 0xF );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
 
     logicalAddress = -1;
     result = HdmiCecRemoveLogicalAddress( handle, -1 );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecClose(handle);
     if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("close failed"); }
@@ -1012,28 +1011,28 @@ void test_hdmicec_hal_l1_getLogicalAddress_sinkDevice_negative( void )
     UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecGetLogicalAddress(0, &logicalAddress);
-    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
 
     result = HdmiCecGetLogicalAddress(handle, NULL);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
 
     result = HdmiCecGetLogicalAddress(handle, &logicalAddressCrossCheck);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
-    UT_ASSERT_TRUE( (int)0xF!= logicalAddressCrossCheck);
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    UT_ASSERT_TRUE( (int)0xF== logicalAddressCrossCheck);
 
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
 
     result = HdmiCecGetLogicalAddress(handle, &logicalAddressCrossCheck);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
-    UT_ASSERT_TRUE( logicalAddress!= logicalAddressCrossCheck);
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    UT_ASSERT_TRUE( logicalAddress== logicalAddressCrossCheck);
 
     result = HdmiCecRemoveLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecGetLogicalAddress(handle, &logicalAddressCrossCheck);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
-    UT_ASSERT_TRUE( (int)0xF!= logicalAddressCrossCheck);
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    UT_ASSERT_TRUE( (int)0xF== logicalAddressCrossCheck);
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
@@ -1081,14 +1080,14 @@ void test_hdmicec_hal_l1_getLogicalAddress_sinkDevice_positive ( void )
     UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecGetLogicalAddress(handle, &logicalAddressCrossCheck);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
-    UT_ASSERT_TRUE( logicalAddress!= logicalAddressCrossCheck);
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    UT_ASSERT_TRUE( logicalAddress== logicalAddressCrossCheck);
 
     result = HdmiCecRemoveLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
@@ -1140,13 +1139,13 @@ void test_hdmicec_hal_l1_getLogicalAddress_sourceDevice_negative( void )
     UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecGetLogicalAddress(0,  &logicalAddress);
-    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
 
     result = HdmiCecGetLogicalAddress(handle, NULL);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
 
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
     UT_ASSERT_TRUE(logicalAddress>0x0E && logicalAddress<0x01);
 
     /*calling hdmicec_close should pass */
@@ -1194,7 +1193,7 @@ void test_hdmicec_hal_l1_getLogicalAddress_sourceDevice_positive( void )
     UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
     UT_ASSERT_TRUE(logicalAddress>0x0E && logicalAddress<0x01);
 
     /*calling hdmicec_close should pass */
@@ -1244,7 +1243,7 @@ void test_hdmicec_hal_l1_setRxCallback_negative ( void )
     UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecSetRxCallback(0, DriverReceiveCallback, (void*)0xDEADBEEF);
-    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecSetRxCallback failed"); } 
+    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetRxCallback failed"); } 
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
@@ -1312,20 +1311,20 @@ void test_hdmicec_hal_l1_setRxCallback_positive( void )
 
     //Get logical address for STB
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
 
     //Using NULL callback
     result = HdmiCecSetRxCallback(0, DriverReceiveCallback, 0);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecSetRxCallback failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetRxCallback failed"); }
 
     /* Positive result */
     result = HdmiCecSetRxCallback(handle, DriverReceiveCallback, (void*)0xDEADBEEF);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecSetRxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetRxCallback failed"); }
 
 
     //Using NULL callback
     result = HdmiCecSetRxCallback(handle, NULL, 0);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("ChHdmiCecSetRxCallbackeck failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("ChHdmiCecSetRxCallbackeck failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
@@ -1366,14 +1365,14 @@ void test_hdmicec_hal_l1_setTxCallback_negative( void )
 
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     result = HdmiCecSetTxCallback( handle, DriverTransmitCallback, (void*)0xDEADBEEF );
-    if (HDMI_CEC_IO_NOT_OPENED  != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecSetTxCallback failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetTxCallback failed"); }
 
     result = HdmiCecOpen ( &handle );
     //if init is failed no need to proceed further
     UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecSetTxCallback(0, NULL, (void*)0xDEADBEEF);
-    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecSetTxCallback failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetTxCallback failed"); }
     
     result = HdmiCecClose( handle );
     if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("HdmiCecClose failed"); }
@@ -1419,10 +1418,10 @@ void test_hdmicec_hal_l1_setTxCallback_positive( void )
     UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecSetTxCallback( handle, DriverTransmitCallback, (void*)0xDEADBEEF );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecSetTxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetTxCallback failed"); }
 
     result = HdmiCecSetTxCallback( handle, NULL, (void*)0xDEADBEEF );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecSetTxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetTxCallback failed"); }
 
     result = HdmiCecClose( handle );
     if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("HdmiCecClose failed"); }
@@ -1492,7 +1491,7 @@ void test_hdmicec_hal_l1_hdmiCecTx_sinkDevice_negative( void )
     logicalAddress = DEFAULT_LOGICAL_ADDRESS;
 
     result = HdmiCecTx(handle, buf, len, &ret);
-    if (HDMI_CEC_IO_SENT_FAILED != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SENT_FAILED != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
 
     //Set logical address for TV
     //logicalAddress = 0;
@@ -1508,37 +1507,37 @@ void test_hdmicec_hal_l1_hdmiCecTx_sinkDevice_negative( void )
 
     //Get logical address
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
 
     /* Invalid input */
     result = HdmiCecTx(handle, buf, len, NULL);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
 
     /* Invalid input */
     result = HdmiCecTx(handle, NULL, len, &ret);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
 
     /* Invalid input */
     result = HdmiCecTx(0, buf, len, &ret);
-    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
 
     /* Invalid input */
     result = HdmiCecTx(handle, buf, INT_MIN, &ret);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
 
     UT_LOG ("\n hdmicec logicalAddress: 0x%x\n", (logicalAddress&0xFF)<<4);
     buf[0] = ((logicalAddress&0xFF)<<4)|0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     /* Positive result */
     result = HdmiCecTx(handle, buf, len, &ret);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTx failed"); }
-    if (HDMI_CEC_IO_SENT_AND_ACKD != ret) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SENT_AND_ACKD != ret) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
 
     buf [1] = CEC_DEVICE_VENDOR_ID;
     /*Back to back send and ensure send is not failed.*/
     result = HdmiCecTx(handle, buf, len, &ret);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTx failed"); }
-    if (HDMI_CEC_IO_SENT_AND_ACKD != ret) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SENT_AND_ACKD != ret) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
@@ -1610,7 +1609,7 @@ void test_hdmicec_hal_l1_hdmiCecTx_sinkDevice_positive( void )
 
     //Get logical address
     result = HdmiCecGetLogicalAddress(handle,  &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
 
 
     UT_LOG ("\n hdmicec logicalAddress: 0x%x\n", (logicalAddress&0xFF)<<4);
@@ -1618,8 +1617,8 @@ void test_hdmicec_hal_l1_hdmiCecTx_sinkDevice_positive( void )
 
     /* Positive result */
     result = HdmiCecTx(handle, buf, len, &ret);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTx failed"); }
-    if (HDMI_CEC_IO_SENT_AND_ACKD != ret) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SENT_AND_ACKD != ret) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
@@ -1687,37 +1686,37 @@ void test_hdmicec_hal_l1_hdmiCecTx_sourceDevice_negative( void )
 
     //Get logical address
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
 
     /* Invalid input */
     result = HdmiCecTx(handle, buf, len, NULL);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
 
     /* Invalid input */
     result = HdmiCecTx(handle, NULL, len, &ret);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
 
     /* Invalid input */
     result = HdmiCecTx(0, buf, len, &ret);
-    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
 
     /* Invalid input */
     result = HdmiCecTx(handle, buf, INT_MIN, &ret);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
 
     UT_LOG ("\n hdmicec logicalAddress: 0x%x\n", (logicalAddress&0xFF)<<4);
     buf[0] = ((logicalAddress&0xFF)<<4)|0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     /* Positive result */
     result = HdmiCecTx(handle, buf, len, &ret);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTx failed"); }
-    if (HDMI_CEC_IO_SENT_AND_ACKD != ret) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("Check failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SENT_AND_ACKD != ret) { HDMICEC_TERM(); UT_FAIL ("Check failed"); }
 
     buf [1] = CEC_DEVICE_VENDOR_ID;
     /*Back to back send and ensure send is not failed*/
     result = HdmiCecTx(handle, buf, len, &ret);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTx failed"); }
-    if (HDMI_CEC_IO_SENT_AND_ACKD != ret) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SENT_AND_ACKD != ret) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
@@ -1775,15 +1774,15 @@ void test_hdmicec_hal_l1_hdmiCecTx_sourceDevice_positive( void )
 
     //Get logical address
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
 
     UT_LOG ("\n hdmicec logicalAddress: 0x%x\n", (logicalAddress&0xFF)<<4);
     buf[0] = ((logicalAddress&0xFF)<<4)|0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     /* Positive result */
     result = HdmiCecTx(handle, buf, len, &ret);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTx failed"); }
-    if (HDMI_CEC_IO_SENT_AND_ACKD != ret) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SENT_AND_ACKD != ret) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
@@ -1832,7 +1831,7 @@ void test_hdmicec_hal_l1_portDisconnected_sink( void )
 
     /* Positive result */
     result = HdmiCecSetRxCallback(handle, DriverReceiveCallback, (void*)0xDEADBEEF);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecSetRxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetRxCallback failed"); }
 
     //Set logical address for TV.
     logicalAddress = 0;
@@ -1840,21 +1839,21 @@ void test_hdmicec_hal_l1_portDisconnected_sink( void )
     if (HDMI_CEC_IO_SUCCESS != result) {
         /*Cleanup before exiting */
         result = HdmiCecClose (handle);
-        if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecClose failed"); }
-        HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed");
+        if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecClose failed"); }
+        HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed");
     }
 
     //Get logical address of the device
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
 
     result = HdmiCecTx(handle, buf, sizeof(buf), &ret);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTx failed"); }
-    if (HDMI_CEC_IO_SENT_BUT_NOT_ACKD != ret) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SENT_BUT_NOT_ACKD != ret) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
 
     //Using NULL callback
     result = HdmiCecSetRxCallback(handle, NULL, 0);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecSetRxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetRxCallback failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
@@ -1917,50 +1916,50 @@ void test_hdmicec_hal_l1_hdmiCecTxAsync_sinkDevice_negative( void )
 
     /* Positive result */
     result = HdmiCecSetTxCallback(handle, DriverTransmitCallback, 0);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecSetTxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetTxCallback failed"); }
 
     //Set logical address for TV
     logicalAddress = DEFAULT_LOGICAL_ADDRESS;
 
     result = HdmiCecTxAsync(handle, buf, len);
-    if (HDMI_CEC_IO_SENT_FAILED != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_SENT_FAILED != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
 
     result = HdmiCecAddLogicalAddress(handle, logicalAddress);
     if (HDMI_CEC_IO_SUCCESS != result) {
         /*Cleanup before exiting */
         result = HdmiCecClose (handle);
-        if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecClose failed"); }
-        HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed");
+        if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecClose failed"); }
+        HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed");
     }
 
     buf[0] = 0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     //Get logical address
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
 
     /* Invalid input */
     result = HdmiCecTxAsync(handle, NULL, len);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
 
     result = HdmiCecTxAsync(0, buf, len);
-    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
 
     /* Invalid input */
     result = HdmiCecTxAsync(handle, buf, INT_MIN);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
 
 
     buf[0] = ((logicalAddress&0xFF)<<4)|0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     /* Positive result */
     result = HdmiCecTxAsync(handle, buf, len);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
 
     buf [1] = CEC_DEVICE_VENDOR_ID;
     /*Back to back send and ensure send is not failed*/
     result = HdmiCecTxAsync(handle, buf, len);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
@@ -2016,7 +2015,7 @@ void test_hdmicec_hal_l1_hdmiCecTxAsync_sinkDevice_positive( void )
 
     /* Positive result */
     result = HdmiCecSetTxCallback(handle, DriverTransmitCallback, 0);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecSetTxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetTxCallback failed"); }
 
     //Set logical address for TV
     logicalAddress = DEFAULT_LOGICAL_ADDRESS;
@@ -2033,14 +2032,14 @@ void test_hdmicec_hal_l1_hdmiCecTxAsync_sinkDevice_positive( void )
 
     //Get logical address
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
 
 
     buf[0] = ((logicalAddress&0xFF)<<4)|0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     /* Positive result */
     result = HdmiCecTxAsync(handle, buf, len);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
@@ -2104,35 +2103,35 @@ void test_hdmicec_hal_l1_hdmiCecTxAsync_sourceDevice_negative( void )
 
     /* Positive result */
     result = HdmiCecSetTxCallback(handle, DriverTransmitCallback, 0);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecSetTxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetTxCallback failed"); }
 
     buf[0] = 0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     //Get logical address
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
 
     /* Invalid input */
     result = HdmiCecTxAsync(handle, NULL, len);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
 
     result = HdmiCecTxAsync(0, buf, len);
-    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
 
     /* Invalid input */
     result = HdmiCecTxAsync(handle, buf, INT_MIN);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
 
     buf[0] = ((logicalAddress&0xFF)<<4)|0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     /* Positive result */
     result = HdmiCecTxAsync(handle, buf, len);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
 
     buf [1] = CEC_DEVICE_VENDOR_ID;
     /*Back to back send and ensure send is not failed*/
     result = HdmiCecTxAsync(handle, buf, len);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
@@ -2188,19 +2187,19 @@ void test_hdmicec_hal_l1_hdmiCecTxAsync_sourceDevice_positive( void )
 
     /* Positive result */
     result = HdmiCecSetTxCallback(handle, DriverTransmitCallback, 0);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecSetTxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetTxCallback failed"); }
 
     buf[0] = 0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     //Get logical address
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
 
     buf[0] = ((logicalAddress&0xFF)<<4)|0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     /* Positive result */
     result = HdmiCecTxAsync(handle, buf, len);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
@@ -2252,19 +2251,19 @@ void test_hdmicec_hal_l1_portDisconnected_source( void )
 
     /* Positive result */
     result = HdmiCecSetRxCallback(handle, DriverReceiveCallback, (void*)0xDEADBEEF);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecSetRxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetRxCallback failed"); }
 
     //Get logical address of the device
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
 
     result = HdmiCecTx(handle, buf, sizeof(buf), &ret);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTx failed"); }
-    if (HDMI_CEC_IO_SENT_BUT_NOT_ACKD != ret) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SENT_BUT_NOT_ACKD != ret) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
 
     //Using NULL callback
     result = HdmiCecSetRxCallback(handle, NULL, 0);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_ASSERT_AUTO_TERM(); UT_FAIL ("HdmiCecSetRxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetRxCallback failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);

--- a/src/test_l1_hdmi_cec_driver.c
+++ b/src/test_l1_hdmi_cec_driver.c
@@ -140,20 +140,20 @@ void DriverReceiveCallback(int handle, void *callbackData, unsigned char *buf, i
     UT_LOG ("\nBuffer generated: %x length: %d\n",buf, len);
     if((handle!=0) && (callbackData !=NULL) && (len>0)) {
             cec_isPingTriggeredl1_g = true;
-            UT_LOG ("\nCall back data generated is \n");
+            UT_LOG("\nCall back data generated is \n");
             for (int index=0; index < len; index++) {
-                    UT_LOG ("buf at index : %d is %x", index, buf[index]);
+                    UT_LOG("buf at index : %d is %x", index, buf[index]);
             }
     }
     else {
         if (handle == 0) {
-            UT_FAIL ("Error: Invalid handle.\n");
+            UT_FAIL("Error: Invalid handle.\n");
         }
         if (callbackData == NULL) {
-            UT_FAIL ("Error: Null callback data.\n");
+            UT_FAIL("Error: Null callback data.\n");
         }
         if (len <= 0) {
-            UT_FAIL ("Error: Invalid length.\n");
+            UT_FAIL("Error: Invalid length.\n");
         }
     }
 }
@@ -199,10 +199,10 @@ void getReceiverLogicalAddressL1 (int handle, int logicalAddress, unsigned char*
             UT_LOG ("\n buf is : 0x%x ret value is  : 0x%x result is : 0x%x \n", buf[0], ret, result);
             if (((HDMI_CEC_IO_SENT_AND_ACKD  == ret)||(HDMI_CEC_IO_SUCCESS==ret))&& (HDMI_CEC_IO_SUCCESS == result) ){
                 *receiverLogicalAddress = addr;
-                UT_LOG ("\n Logical address of the receiver is : 0x%x\n", *receiverLogicalAddress); break;
+                UT_LOG("\n Logical address of the receiver is : 0x%x\n", *receiverLogicalAddress); break;
                 break;
             } else {
-                UT_LOG ("\n failed to receive logical address  ret:0x%x result:0x%x\n", ret, result);
+                UT_LOG("\n failed to receive logical address  ret:0x%x result:0x%x\n", ret, result);
             }
         }
     }
@@ -246,16 +246,17 @@ void test_hdmicec_hal_l1_open_negative( void )
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     //Check Null even before calling the positive case
     result = HdmiCecOpen( NULL );
-    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { UT_FAIL_FATAL ("open failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { UT_FAIL("open failed"); }
 
     result = HdmiCecOpen( &handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("open failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("open failed"); }
     
     result = HdmiCecOpen( &handle );
-    if (HDMI_CEC_IO_ALREADY_OPEN != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("open failed"); }
+    if (HDMI_CEC_IO_ALREADY_OPEN != result) { UT_FAIL("open failed"); }
 
     result = HdmiCecClose( handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("close failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("close failed"); }
+
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
 }
@@ -293,10 +294,11 @@ void test_hdmicec_hal_l1_open_positive( void )
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     
     result = HdmiCecOpen( &handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("open failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("open failed"); }
 
     result = HdmiCecClose( handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("close failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("close failed"); }
+
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
 }
@@ -333,14 +335,14 @@ void test_hdmicec_hal_l1_open_logical_address_unavailable_source ( void )
     UT_LOG ("\nPlease connect other 4 cec enabled playback devices to the cec network. \
                   Please enter any key to continue"); getchar ();
     result = HdmiCecOpen( &handle );
-    if (HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE != result) { UT_FAIL_FATAL ("open failed"); }
-    
+    if (HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE != result) { UT_FAIL_FATAL("open failed"); }
     //The above open is failed handle should be null
     UT_ASSERT_TRUE_FATAL(handle!=0);
 
      //Here handle = 0 since open failed and close should fail.
     result = HdmiCecClose( handle );
-    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { UT_FAIL_FATAL ("close failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { UT_FAIL_FATAL("close failed"); }
+
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
 }
@@ -363,8 +365,8 @@ void test_hdmicec_hal_l1_open_logical_address_unavailable_source ( void )
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|---------|----------|--------------|-----|
  * |01|Call HdmiCecClose() - close interface even before opening it | handle | HDMI_CEC_IO_NOT_OPENED| Should Pass |
- * |02|Call HdmiCecClose () - call with invalid handle | handle=0 | HDMI_CEC_IO_INVALID_HANDLE| Should Pass |
- * |03|Call HdmiCecOpen() - open interface | handle | HDMI_CEC_IO_SUCCESS| Should Pass |
+ * |02|Call HdmiCecOpen() - open interface | handle | HDMI_CEC_IO_SUCCESS| Should Pass |
+ * |03|Call HdmiCecClose () - call with invalid handle | handle=0 | HDMI_CEC_IO_INVALID_HANDLE| Should Pass |
  * |04|Call HdmiCecClose () - close interface | handle=hdmiHandle | HDMI_CEC_IO_SUCCESS| Should Pass |
  * |05|Call HdmiCecClose () - close interface again | handle=hdmiHandle | HDMI_CEC_IO_NOT_OPENED| Should Pass |
  */
@@ -376,19 +378,20 @@ void test_hdmicec_hal_l1_close_negative( void )
 
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     result = HdmiCecClose( handle );
-    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL_FATAL ("close failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL("close failed"); }
 
     result = HdmiCecOpen( &handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("open failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("open failed"); }
 
     result = HdmiCecClose( 0 );
-    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("close failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { UT_FAIL("close failed"); }
 
     result = HdmiCecClose( handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("close failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("close failed"); }
 
     result = HdmiCecClose( handle );
-    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL_FATAL ("close failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL("close failed"); }
+
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
 
@@ -423,16 +426,16 @@ void test_hdmicec_hal_l1_close_positive( void )
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
     result = HdmiCecOpen( &handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("open failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("open failed"); }
 
     result = HdmiCecClose( handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("close failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("close failed"); }
 
     result = HdmiCecOpen( &handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("open failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("open failed"); }
 
     result = HdmiCecClose( handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("close failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("close failed"); }
 
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
@@ -472,35 +475,37 @@ void test_hdmicec_hal_l1_getPhysicalAddress_negative( void )
 
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     result = HdmiCecGetPhysicalAddress(handle, &physicalAddress);
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecGetPhysicalAddress failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL("HdmiCecGetPhysicalAddress failed"); }
 
 
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecGetPhysicalAddress(0, &physicalAddress);
-    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetPhysicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { UT_FAIL("HdmiCecGetPhysicalAddress failed"); }
 
     result = HdmiCecGetPhysicalAddress(handle, NULL);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetPhysicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { UT_FAIL("HdmiCecGetPhysicalAddress failed"); }
 
 
     result = HdmiCecGetPhysicalAddress(handle, &physicalAddress);
-    if (HDMI_CEC_IO_SUCCESS  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetPhysicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS  != result) { UT_FAIL("HdmiCecGetPhysicalAddress failed"); }
+
     unsigned int maxVal = (((0x04 &0xF0 ) << 20)|( (0x04 &0x0F ) << 16) |((0x04 & 0xF0) << 4)  | (0x04 & 0x0F));
     //Max possible physical address is 4.4.4.4
     if (physicalAddress>maxVal) {
-        HDMICEC_TERM(); UT_FAIL_FATAL ("physicalAddress miss match failed");
+        UT_FAIL ("physicalAddress miss match failed");
     }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("close failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("close failed"); }
 
     //Calling API after close,
     result = HdmiCecGetPhysicalAddress(handle, &physicalAddress);
-    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL_FATAL ("HdmiCecGetPhysicalAddress failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL("HdmiCecGetPhysicalAddress failed"); }
+
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
 
@@ -536,17 +541,17 @@ void test_hdmicec_hal_l1_getPhysicalAddress_positive( void )
 
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecGetPhysicalAddress(handle, &physicalAddress);
-    if (HDMI_CEC_IO_SUCCESS  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetPhysicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS  != result) { UT_FAIL("HdmiCecGetPhysicalAddress failed"); }
     if(physicalAddress == 0xffff){
 	    UT_FAIL("Invalid physicalAddress ");
     }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("close failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("close failed"); }
 
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
@@ -589,31 +594,33 @@ void test_hdmicec_hal_l1_addLogicalAddress_sinkDevice_negative( void )
     gTestID = 8;
 
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL(result, HDMI_CEC_IO_SUCCESS );
 
 
     result = HdmiCecAddLogicalAddress( 0, logicalAddress );
-    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { UT_FAIL("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecAddLogicalAddress( handle, -1 );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { UT_FAIL("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecAddLogicalAddress( handle, 0x3 );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { UT_FAIL("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecAddLogicalAddress( handle, 0xF );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { UT_FAIL("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecClose( handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("close failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("close failed"); }
 
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL("HdmiCecAddLogicalAddress failed"); }
+
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
 }
@@ -654,14 +661,14 @@ void test_hdmicec_hal_l1_addLogicalAddress_sinkDevice_positive( void )
 
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL(result, HDMI_CEC_IO_SUCCESS );
 
     logicalAddress = DEFAULT_LOGICAL_ADDRESS_PANEL;
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecClose( handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("close failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("close failed"); }
 
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
@@ -705,33 +712,34 @@ void test_hdmicec_hal_l1_addLogicalAddress_sourceDevice( void )
 
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_NOT_OPENED  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL(result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecAddLogicalAddress( 0, logicalAddress );
-    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { UT_FAIL("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecAddLogicalAddress( handle, -1 );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { UT_FAIL("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecAddLogicalAddress( handle, 0x3 );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { UT_FAIL("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecAddLogicalAddress( handle, 0xF );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { UT_FAIL("HdmiCecAddLogicalAddress failed"); }
 
     logicalAddress = DEFAULT_LOGICAL_ADDRESS_STB;
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { UT_FAIL("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecClose( handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("Close failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("Close failed"); }
 
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL("HdmiCecAddLogicalAddress failed"); }
+
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
 }
@@ -770,13 +778,13 @@ void test_hdmicec_hal_l1_addLogicalAddressWithAddressInUse_sinkDevice( void )
     UT_LOG ("\nPlease connect another CEC enabled sink device to the device. Please enter any key to continue"); getchar ();
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL(result, HDMI_CEC_IO_SUCCESS );
     
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE != result) { UT_FAIL("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecClose( handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("close failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("close failed"); }
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
 }
@@ -821,41 +829,42 @@ void test_hdmicec_hal_l1_removeLogicalAddress_sinkDevice_negative( void )
 
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     result = HdmiCecRemoveLogicalAddress(handle, logicalAddress );
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecOpen(&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecRemoveLogicalAddress( 0, logicalAddress );
-    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { UT_FAIL("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecRemoveLogicalAddress( handle, 0xF );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { UT_FAIL("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecRemoveLogicalAddress( handle,  -1 );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { UT_FAIL("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecRemoveLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecRemoveLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_ALREADY_REMOVED != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_ALREADY_REMOVED != result) { UT_FAIL("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecRemoveLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecRemoveLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_ALREADY_REMOVED != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_ALREADY_REMOVED != result) { UT_FAIL("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecClose(handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("close failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("close failed"); }
 
     result = HdmiCecRemoveLogicalAddress(handle, logicalAddress );
-    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL("HdmiCecRemoveLogicalAddress failed"); }
+
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
 }
@@ -893,16 +902,18 @@ void test_hdmicec_hal_l1_removeLogicalAddress_sinkDevice_positive( void )
 
     result = HdmiCecOpen(&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
-
+    UT_ASSERT_EQUAL_FATAL( result, HDMI_CEC_IO_SUCCESS );
+//check need to remove/add fatal
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecRemoveLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecClose(handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("close failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("close failed"); }
+
+    UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
 }
 
@@ -941,32 +952,34 @@ void test_hdmicec_hal_l1_removeLogicalAddress_sourceDevice( void )
     gTestID = 14;
 
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
     result = HdmiCecRemoveLogicalAddress(handle, logicalAddress );
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecOpen(&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecRemoveLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { UT_FAIL("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecRemoveLogicalAddress( 0, logicalAddress );
-    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { UT_FAIL("HdmiCecRemoveLogicalAddress failed"); }
 
     logicalAddress = 0xF;
     result = HdmiCecRemoveLogicalAddress( handle, 0xF );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { UT_FAIL("HdmiCecRemoveLogicalAddress failed"); }
 
     logicalAddress = -1;
     result = HdmiCecRemoveLogicalAddress( handle, -1 );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { UT_FAIL("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecClose(handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("close failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("close failed"); }
 
     result = HdmiCecRemoveLogicalAddress(handle, logicalAddress );
-    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL("HdmiCecRemoveLogicalAddress failed"); }
+
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
 }
@@ -1011,49 +1024,50 @@ void test_hdmicec_hal_l1_getLogicalAddress_sinkDevice_negative( void )
 
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL("HdmiCecGetLogicalAddress failed"); }
 
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecGetLogicalAddress(0, &logicalAddress);
-    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE != result) { UT_FAIL("HdmiCecGetLogicalAddress failed"); }
 
     result = HdmiCecGetLogicalAddress(handle, NULL);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { UT_FAIL("HdmiCecGetLogicalAddress failed"); }
 
     result = HdmiCecGetLogicalAddress(handle, &logicalAddressCrossCheck);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecGetLogicalAddress failed"); }
     if((int)0xF!= logicalAddressCrossCheck){
 	    UT_FAIL("Invalid logicalAddress ");
     }
 
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecGetLogicalAddress failed"); }
 
     result = HdmiCecGetLogicalAddress(handle, &logicalAddressCrossCheck);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecGetLogicalAddress failed"); }
     if(logicalAddress != logicalAddressCrossCheck){
 	    UT_FAIL("logicalAddress and logicalAddressCrossCheck are not same");
     }
 
     result = HdmiCecRemoveLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecGetLogicalAddress(handle, &logicalAddressCrossCheck);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecGetLogicalAddress failed"); }
     if((int)0xF!= logicalAddressCrossCheck){
 	    UT_FAIL("Invalid logicalAddress");
     }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("HdmiCecClose failed"); }
 
     //Calling API after close, should give invalid argument
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL("HdmiCecGetLogicalAddress failed"); }
+
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
 
@@ -1091,23 +1105,23 @@ void test_hdmicec_hal_l1_getLogicalAddress_sinkDevice_positive ( void )
 
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecGetLogicalAddress(handle, &logicalAddressCrossCheck);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecGetLogicalAddress failed"); }
     if(logicalAddress != logicalAddressCrossCheck){
              UT_FAIL("logicalAddress and logicalAddressCrossCheck are not same");
      }
 
     result = HdmiCecRemoveLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecRemoveLogicalAddress failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("HdmiCecClose failed"); }
 
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
@@ -1148,31 +1162,32 @@ void test_hdmicec_hal_l1_getLogicalAddress_sourceDevice_negative( void )
 
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     result = HdmiCecGetLogicalAddress(handle,  &logicalAddress);
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL("HdmiCecGetLogicalAddress failed"); }
 
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecGetLogicalAddress(0,  &logicalAddress);
-    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE != result) { UT_FAIL("HdmiCecGetLogicalAddress failed"); }
 
     result = HdmiCecGetLogicalAddress(handle, NULL);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { UT_FAIL("HdmiCecGetLogicalAddress failed"); }
 
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecGetLogicalAddress failed"); }
     if(logicalAddress<=0 || logicalAddress>0x0B || (logicalAddress==0x0F)){
 	    UT_FAIL("Invalid logicalAddress");
     }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("HdmiCecClose failed"); }
 
     //Calling API after close, should give invalid argument
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL("HdmiCecGetLogicalAddress failed"); }
+
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
 
@@ -1208,17 +1223,19 @@ void test_hdmicec_hal_l1_getLogicalAddress_sourceDevice_positive( void )
 
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecGetLogicalAddress failed"); }
     if(logicalAddress<=0 || logicalAddress>0x0B || (logicalAddress==0x0F)){
             UT_LOG("Invalid logicalAddress 0x%x\n",logicalAddress);
     }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("HdmiCecClose failed"); }
+
+    UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
 
 /**
@@ -1254,23 +1271,23 @@ void test_hdmicec_hal_l1_setRxCallback_negative ( void )
 
     //Calling API before open, should pass
     result = HdmiCecSetRxCallback(handle, DriverReceiveCallback, (void*)0xDEADBEEF);
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecSetRxCallback failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL("HdmiCecSetRxCallback failed"); }
 
     /* Positive result */
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecSetRxCallback(0, DriverReceiveCallback, (void*)0xDEADBEEF);
-    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetRxCallback failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE != result) { UT_FAIL("HdmiCecSetRxCallback failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("HdmiCecClose failed"); }
 
     //Calling API after close, should return success
     result = HdmiCecSetRxCallback(handle, DriverReceiveCallback, 0);
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecSetRxCallback failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL("HdmiCecSetRxCallback failed"); }
 
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
@@ -1308,18 +1325,18 @@ void test_hdmicec_hal_l1_setRxCallback_positive( void )
     /* Positive result */
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL( result, HDMI_CEC_IO_SUCCESS );
 
     /* Positive result */
     result = HdmiCecSetRxCallback(handle, DriverReceiveCallback, (void*)0xDEADBEEF);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetRxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecSetRxCallback failed"); }
 
     result = HdmiCecSetRxCallback( handle, NULL, (void*)0xDEADBEEF );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetTxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecSetTxCallback failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("HdmiCecClose failed"); }
 
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
@@ -1355,20 +1372,20 @@ void test_hdmicec_hal_l1_setTxCallback_negative( void )
 
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     result = HdmiCecSetTxCallback( handle, DriverTransmitCallback, (void*)0xDEADBEEF );
-    if (HDMI_CEC_IO_NOT_OPENED  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetTxCallback failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL("HdmiCecSetTxCallback failed"); }
 
     result = HdmiCecOpen ( &handle );
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecSetTxCallback(0, NULL, (void*)0xDEADBEEF);
-    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetTxCallback failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE != result) { UT_FAIL("HdmiCecSetTxCallback failed"); }
     
     result = HdmiCecClose( handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("HdmiCecClose failed"); }
 
     result = HdmiCecSetTxCallback( handle, DriverTransmitCallback, (void*)0xDEADBEEF );
-    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL_FATAL ("HdmiCecSetTxCallback failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL("HdmiCecSetTxCallback failed"); }
 
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
@@ -1404,16 +1421,16 @@ void test_hdmicec_hal_l1_setTxCallback_positive( void )
 
     result = HdmiCecOpen ( &handle );
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecSetTxCallback( handle, DriverTransmitCallback, (void*)0xDEADBEEF );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetTxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecSetTxCallback failed"); }
 
     result = HdmiCecSetTxCallback( handle, NULL, (void*)0xDEADBEEF );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetTxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecSetTxCallback failed"); }
 
     result = HdmiCecClose( handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("HdmiCecClose failed"); }
 
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
@@ -1466,52 +1483,53 @@ void test_hdmicec_hal_l1_hdmiCecTx_sinkDevice_negative( void )
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     //Calling API before open, should give invalid argument
     result = HdmiCecTx(handle, buf, len, &ret);
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL("HdmiCecTx failed"); }
 
     /* Positive result */
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL( result, HDMI_CEC_IO_SUCCESS );
 
     logicalAddress = DEFAULT_LOGICAL_ADDRESS_PANEL;
 
     result = HdmiCecTx(handle, buf, len, &ret);
-    if (HDMI_CEC_IO_SENT_FAILED != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SENT_FAILED != result) { UT_FAIL("HdmiCecTx failed"); }
 
     //Set logical address for TV
     //logicalAddress = 0;
     result = HdmiCecAddLogicalAddress(handle, logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecAddLogicalAddress failed"); }
 
     buf[0] = 0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     //Get logical address
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecGetLogicalAddress failed"); }
 
     /* Invalid input */
     result = HdmiCecTx(handle, buf, len, NULL);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { UT_FAIL("HdmiCecTx failed"); }
 
     /* Invalid input */
     result = HdmiCecTx(handle, NULL, len, &ret);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { UT_FAIL("HdmiCecTx failed"); }
 
     /* Invalid input */
     result = HdmiCecTx(0, buf, len, &ret);
-    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE != result) { UT_FAIL("HdmiCecTx failed"); }
 
     /* Invalid input */
     result = HdmiCecTx(handle, buf, INT_MIN, &ret);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { UT_FAIL("HdmiCecTx failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("HdmiCecClose failed"); }
 
     //Calling API after close, should give invalid argument
     result = HdmiCecTx(handle, buf, len, &ret);
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL("HdmiCecTx failed"); }
+
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
 
@@ -1557,20 +1575,20 @@ void test_hdmicec_hal_l1_hdmiCecTx_sinkDevice_positive( void )
     /* Positive result */
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL( result, HDMI_CEC_IO_SUCCESS );
 
     logicalAddress = DEFAULT_LOGICAL_ADDRESS_PANEL;
 
     //Set logical address for TV
     //logicalAddress = 0;
     result = HdmiCecAddLogicalAddress(handle, logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecAddLogicalAddress failed"); }
 
     buf[0] = 0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     //Get logical address
     result = HdmiCecGetLogicalAddress(handle,  &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecGetLogicalAddress failed"); }
 
 
     UT_LOG ("\n hdmicec logicalAddress: 0x%x\n", (logicalAddress&0xFF)<<4);
@@ -1578,12 +1596,12 @@ void test_hdmicec_hal_l1_hdmiCecTx_sinkDevice_positive( void )
 
     /* Positive result */
     result = HdmiCecTx(handle, buf, len, &ret);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
-    if (HDMI_CEC_IO_SENT_AND_ACKD != ret) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SENT_BUT_NOT_ACKD != ret) { UT_FAIL("HdmiCecTx failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("HdmiCecClose failed"); }
 
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
@@ -1633,44 +1651,46 @@ void test_hdmicec_hal_l1_hdmiCecTx_sourceDevice_negative( void )
     unsigned char buf[] = {0x3F, CEC_GET_CEC_VERSION};
 
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
     //Calling API before open, should give not open error
     result = HdmiCecTx(handle, buf, len, &ret);
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL("HdmiCecTx failed"); }
 
     /* Positive result */
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL( result, HDMI_CEC_IO_SUCCESS );
 
     buf[0] = 0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     //Get logical address
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecGetLogicalAddress failed"); }
 
     /* Invalid input */
     result = HdmiCecTx(handle, buf, len, NULL);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { UT_FAIL("HdmiCecTx failed"); }
 
     /* Invalid input */
     result = HdmiCecTx(handle, NULL, len, &ret);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { UT_FAIL("HdmiCecTx failed"); }
 
     /* Invalid input */
     result = HdmiCecTx(0, buf, len, &ret);
-    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE != result) { UT_FAIL("HdmiCecTx failed"); }
 
     /* Invalid input */
     result = HdmiCecTx(handle, buf, INT_MIN, &ret);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { UT_FAIL("HdmiCecTx failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("HdmiCecClose failed"); }
 
     //Calling API after close, should give invalid argument
     result = HdmiCecTx(handle, buf, len, &ret);
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL("HdmiCecTx failed"); }
+
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
 
@@ -1714,25 +1734,27 @@ void test_hdmicec_hal_l1_hdmiCecTx_sourceDevice_positive( void )
     /* Positive result */
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL( result, HDMI_CEC_IO_SUCCESS );
 
     buf[0] = 0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     //Get logical address
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecGetLogicalAddress failed"); }
 
     UT_LOG ("\n hdmicec logicalAddress: 0x%x\n", (logicalAddress&0xFF)<<4);
     buf[0] = ((logicalAddress&0xFF)<<4)|0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     /* Positive result */
     result = HdmiCecTx(handle, buf, len, &ret);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
-    if (HDMI_CEC_IO_SENT_AND_ACKD != ret) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SENT_BUT_NOT_ACKD != ret) { UT_FAIL("HdmiCecTx failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("HdmiCecClose failed"); }
+
+    UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
 
 /**
@@ -1779,55 +1801,56 @@ void test_hdmicec_hal_l1_hdmiCecTxAsync_sinkDevice_negative( void )
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     //Calling API before open, should give invalid argument
     result = HdmiCecTxAsync(handle, buf, len); //Code crash here
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL("HdmiCecTxAsync failed"); }
 
     /* Positive result */
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL( result, HDMI_CEC_IO_SUCCESS );
 
     /* Positive result */
     result = HdmiCecSetTxCallback(handle, DriverTransmitCallback, 0);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetTxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecSetTxCallback failed"); }
 
     //Set logical address for TV
     logicalAddress = DEFAULT_LOGICAL_ADDRESS_PANEL;
 
     result = HdmiCecTxAsync(handle, buf, len);
-    if (HDMI_CEC_IO_SENT_FAILED != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_SENT_FAILED != result) { UT_FAIL("HdmiCecTxAsync failed"); }
 
     result = HdmiCecAddLogicalAddress(handle, logicalAddress);
     if (HDMI_CEC_IO_SUCCESS != result) {
-        HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed");
+        UT_FAIL("HdmiCecAddLogicalAddress failed");
     }
 
     buf[0] = 0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     //Get logical address
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecGetLogicalAddress failed"); }
 
     /* Invalid input */
     result = HdmiCecTxAsync(handle, NULL, len);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { UT_FAIL("HdmiCecTxAsync failed"); }
 
     result = HdmiCecTxAsync(0, buf, len);
-    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE != result) { UT_FAIL("HdmiCecTxAsync failed"); }
 
     /* Invalid input */
     result = HdmiCecTxAsync(handle, buf, INT_MIN);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { UT_FAIL("HdmiCecTxAsync failed"); }
 
 
     buf[0] = ((logicalAddress&0xFF)<<4)|0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("HdmiCecClose failed"); }
 
     //Calling API after close, should give invalid argument
     result = HdmiCecTxAsync(handle, buf, len);
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL("HdmiCecTxAsync failed"); }
+
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
 
@@ -1871,34 +1894,34 @@ void test_hdmicec_hal_l1_hdmiCecTxAsync_sinkDevice_positive( void )
     /* Positive result */
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL( result, HDMI_CEC_IO_SUCCESS );
 
     /* Positive result */
     result = HdmiCecSetTxCallback(handle, DriverTransmitCallback, 0);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetTxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecSetTxCallback failed"); }
 
     //Set logical address for TV
     logicalAddress = DEFAULT_LOGICAL_ADDRESS_PANEL;
 
     result = HdmiCecAddLogicalAddress(handle, logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecAddLogicalAddress failed"); }
 
     buf[0] = 0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     //Get logical address
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecGetLogicalAddress failed"); }
 
 
     buf[0] = ((logicalAddress&0xFF)<<4)|0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     /* Positive result */
     result = HdmiCecTxAsync(handle, buf, len);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecTxAsync failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("HdmiCecClose failed"); }
 
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
@@ -1945,45 +1968,47 @@ void test_hdmicec_hal_l1_hdmiCecTxAsync_sourceDevice_negative( void )
 
 
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+
     //Calling API before open, should give invalid argument
     result = HdmiCecTxAsync(handle, buf, len); //Code crash here
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL("HdmiCecTxAsync failed"); }
 
     /* Positive result */
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL( result, HDMI_CEC_IO_SUCCESS );
 
     /* Positive result */
     result = HdmiCecSetTxCallback(handle, DriverTransmitCallback, 0);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetTxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecSetTxCallback failed"); }
 
     buf[0] = 0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     //Get logical address
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecGetLogicalAddress failed"); }
 
     /* Invalid input */
     result = HdmiCecTxAsync(handle, NULL, len);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { UT_FAIL("HdmiCecTxAsync failed"); }
 
     result = HdmiCecTxAsync(0, buf, len);
-    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE != result) { UT_FAIL("HdmiCecTxAsync failed"); }
 
     /* Invalid input */
     result = HdmiCecTxAsync(handle, buf, INT_MIN);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { UT_FAIL("HdmiCecTxAsync failed"); }
 
     buf[0] = ((logicalAddress&0xFF)<<4)|0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("HdmiCecClose failed"); }
 
     //Calling API after close, should give invalid argument
     result = HdmiCecTxAsync(handle, buf, len);
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL("HdmiCecTxAsync failed"); }
+
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
 
@@ -2027,27 +2052,27 @@ void test_hdmicec_hal_l1_hdmiCecTxAsync_sourceDevice_positive( void )
     /* Positive result */
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL( result, HDMI_CEC_IO_SUCCESS );
 
     /* Positive result */
     result = HdmiCecSetTxCallback(handle, DriverTransmitCallback, 0);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetTxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecSetTxCallback failed"); }
 
     buf[0] = 0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     //Get logical address
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecGetLogicalAddress failed"); }
 
     buf[0] = ((logicalAddress&0xFF)<<4)|0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     /* Positive result */
     result = HdmiCecTxAsync(handle, buf, len);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecTxAsync failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("HdmiCecClose failed"); }
 
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
@@ -2091,32 +2116,33 @@ void test_hdmicec_hal_l1_portDisconnected_sink( void )
     /* Positive result */
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL( result, HDMI_CEC_IO_SUCCESS );
 
     /* Positive result */
     result = HdmiCecSetRxCallback(handle, DriverReceiveCallback, (void*)0xDEADBEEF);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetRxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecSetRxCallback failed"); }
 
     //Set logical address for TV.
     logicalAddress = 0;
     result = HdmiCecAddLogicalAddress(handle, logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecAddLogicalAddress failed"); }
 
     //Get logical address of the device
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecGetLogicalAddress failed"); }
 
     result = HdmiCecTx(handle, buf, sizeof(buf), &ret);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
-    if (HDMI_CEC_IO_SENT_BUT_NOT_ACKD != ret) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SENT_BUT_NOT_ACKD != ret) { UT_FAIL("HdmiCecTx failed"); }
 
     //Using NULL callback
     result = HdmiCecSetRxCallback(handle, NULL, 0);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetRxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecSetRxCallback failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("HdmiCecClose failed"); }
+
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
 
@@ -2159,40 +2185,36 @@ void test_hdmicec_hal_l1_portDisconnected_source( void )
     /* Positive result */
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL( result, HDMI_CEC_IO_SUCCESS );
 
     /* Positive result */
     result = HdmiCecSetRxCallback(handle, DriverReceiveCallback, (void*)0xDEADBEEF);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetRxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecSetRxCallback failed"); }
 
     //Get logical address of the device
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecGetLogicalAddress failed"); }
 
     result = HdmiCecTx(handle, buf, sizeof(buf), &ret);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
-    if (HDMI_CEC_IO_SENT_BUT_NOT_ACKD != ret) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SENT_BUT_NOT_ACKD != ret) { UT_FAIL("HdmiCecTx failed"); }
 
     //Using NULL callback
     result = HdmiCecSetRxCallback(handle, NULL, 0);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetRxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecSetRxCallback failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL("HdmiCecClose failed"); }
+
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
 
 #endif
 
-static UT_test_suite_t *pSuiteNegative = NULL;
-static UT_test_suite_t *pSuiteHdmiDisConnected = NULL;
-static UT_test_suite_t *pSuitePositive = NULL;
-static UT_test_suite_t *pSuiteLAUS = NULL;
-static UT_test_suite_t *pSuitePositive_stb = NULL;
-static UT_test_suite_t *pSuiteNegative_stb = NULL;
-static UT_test_suite_t *pSuitePositive_panel = NULL;
-static UT_test_suite_t *pSuiteNegative_panel = NULL;
+static UT_test_suite_t *pSuiteCommon = NULL;
+static UT_test_suite_t *pSuite_stb = NULL;
+static UT_test_suite_t *pSuite_panel = NULL;
 
 /**
  * @brief Register the main tests for this module
@@ -2201,60 +2223,48 @@ static UT_test_suite_t *pSuiteNegative_panel = NULL;
  */
 int test_hdmicec_hal_l1_register( void )
 {
-    /* add a suite to the registry */
-    pSuitePositive = UT_add_suite("[L1 HDMICEC Positive common TestCase]", NULL, NULL);
-    pSuiteNegative = UT_add_suite("[L1 HDMICEC Negative common TestCase]", NULL, NULL);
 
-    pSuitePositive_stb = UT_add_suite("[L1 HDMICEC Positive STB TestCase]", NULL, NULL);
-    pSuiteNegative_stb = UT_add_suite("[L1 HDMICEC Negative STB TestCase]", NULL, NULL);
+    pSuiteCommon = UT_add_suite("[L1 HDMICEC Common TestCase]", NULL, NULL);
+    pSuite_stb = UT_add_suite("[L1 HDMICEC STB TestCase]", NULL, NULL);
+    pSuite_panel = UT_add_suite("[L1 HDMICEC PANEL TestCase]", NULL, NULL);
 
-    pSuitePositive_panel = UT_add_suite("[L1 HDMICEC Positive PANEL TestCase]", NULL, NULL);
-    pSuiteNegative_panel = UT_add_suite("[L1 HDMICEC Negative PANEL TestCase]", NULL, NULL);
-
-    pSuiteHdmiDisConnected = UT_add_suite("[L1 HDMI Disconnect]", NULL, NULL);
-    pSuiteLAUS = UT_add_suite("[L1 HDMICEC Logical Address TestCase]", NULL, NULL);
-
-    if ((NULL == pSuiteNegative) || (NULL == pSuitePositive) || (NULL == pSuiteHdmiDisConnected) || (NULL == pSuiteLAUS) || (NULL == pSuitePositive_stb) || (NULL == pSuiteNegative_stb) || (NULL == pSuitePositive_panel) || (NULL == pSuiteNegative_panel))
+    if ((NULL == pSuiteCommon) || (NULL == pSuite_stb) || (NULL == pSuite_panel))
     {
         return -1;
     }
 
-    //
-    UT_add_test( pSuiteNegative, "open_negative", test_hdmicec_hal_l1_open_negative);
-    UT_add_test( pSuiteNegative, "close_negative", test_hdmicec_hal_l1_close_negative);
-    UT_add_test( pSuiteNegative, "getPhysicalAddress_negative", test_hdmicec_hal_l1_getPhysicalAddress_negative);
+    UT_add_test( pSuiteCommon, "open_Positive", test_hdmicec_hal_l1_open_positive);
+    UT_add_test( pSuiteCommon, "open_negative", test_hdmicec_hal_l1_open_negative);
+    UT_add_test( pSuiteCommon, "close_Positive", test_hdmicec_hal_l1_close_positive);
+    UT_add_test( pSuiteCommon, "close_negative", test_hdmicec_hal_l1_close_negative);
+    UT_add_test( pSuiteCommon, "getPhysicalAddress_Positive", test_hdmicec_hal_l1_getPhysicalAddress_positive);
+    UT_add_test( pSuiteCommon, "getPhysicalAddress_negative", test_hdmicec_hal_l1_getPhysicalAddress_negative);
+    UT_add_test( pSuiteCommon, "setRxCallback_Positive", test_hdmicec_hal_l1_setRxCallback_positive);
+    UT_add_test( pSuiteCommon, "setRxCallback_negative", test_hdmicec_hal_l1_setRxCallback_negative);
+    UT_add_test( pSuiteCommon, "setTxCallback_Positive", test_hdmicec_hal_l1_setTxCallback_positive);
+    UT_add_test( pSuiteCommon, "setTxCallback_negative", test_hdmicec_hal_l1_setTxCallback_negative);
 
-    UT_add_test( pSuiteNegative, "setRxCallback_negative", test_hdmicec_hal_l1_setRxCallback_negative);
-    UT_add_test( pSuiteNegative, "setTxCallback_negative", test_hdmicec_hal_l1_setTxCallback_negative);
-
-    UT_add_test( pSuiteNegative_panel, "addLogicalAddressSink_negative", test_hdmicec_hal_l1_addLogicalAddress_sinkDevice_negative);
-    UT_add_test( pSuiteNegative_panel, "removeLogicalAddressSink_negative", test_hdmicec_hal_l1_removeLogicalAddress_sinkDevice_negative);
-    UT_add_test( pSuiteNegative_panel, "getLogicalAddressSink_negative", test_hdmicec_hal_l1_getLogicalAddress_sinkDevice_negative);
-    UT_add_test( pSuiteNegative_panel, "hdmiCecTxSink_negative", test_hdmicec_hal_l1_hdmiCecTx_sinkDevice_negative);
-    UT_add_test( pSuiteNegative_panel, "hdmiCecTxAsyncSink_negative", test_hdmicec_hal_l1_hdmiCecTxAsync_sinkDevice_negative);
-    UT_add_test( pSuiteLAUS, "addLogicalAddressWithAddressInUseSink", test_hdmicec_hal_l1_addLogicalAddressWithAddressInUse_sinkDevice);
-    UT_add_test( pSuitePositive_panel, "addLogicalAddressSink_Positive", test_hdmicec_hal_l1_addLogicalAddress_sinkDevice_positive);
-    UT_add_test( pSuitePositive_panel, "removeLogicalAddressSink_Positive", test_hdmicec_hal_l1_removeLogicalAddress_sinkDevice_positive);
-    UT_add_test( pSuitePositive_panel, "getLogicalAddressSink_Positive", test_hdmicec_hal_l1_getLogicalAddress_sinkDevice_positive);
-    UT_add_test( pSuitePositive_panel, "hdmiCecTxSink_Positive", test_hdmicec_hal_l1_hdmiCecTx_sinkDevice_positive);
-    UT_add_test( pSuitePositive_panel, "hdmiCecTxAsyncSink_Positive", test_hdmicec_hal_l1_hdmiCecTxAsync_sinkDevice_positive);
+    UT_add_test( pSuite_panel, "addLogicalAddressSink_Positive", test_hdmicec_hal_l1_addLogicalAddress_sinkDevice_positive);
+    UT_add_test( pSuite_panel, "addLogicalAddressSink_negative", test_hdmicec_hal_l1_addLogicalAddress_sinkDevice_negative);
+    UT_add_test( pSuite_panel, "removeLogicalAddressSink_Positive", test_hdmicec_hal_l1_removeLogicalAddress_sinkDevice_positive);
+    UT_add_test( pSuite_panel, "removeLogicalAddressSink_negative", test_hdmicec_hal_l1_removeLogicalAddress_sinkDevice_negative);
+    UT_add_test( pSuite_panel, "getLogicalAddressSink_Positive", test_hdmicec_hal_l1_getLogicalAddress_sinkDevice_positive);
+    UT_add_test( pSuite_panel, "getLogicalAddressSink_negative", test_hdmicec_hal_l1_getLogicalAddress_sinkDevice_negative);
+    UT_add_test( pSuite_panel, "TxSink_Positive", test_hdmicec_hal_l1_hdmiCecTx_sinkDevice_positive);
+    UT_add_test( pSuite_panel, "TxSink_negative", test_hdmicec_hal_l1_hdmiCecTx_sinkDevice_negative);
+    UT_add_test( pSuite_panel, "TxAsyncSink_Positive", test_hdmicec_hal_l1_hdmiCecTxAsync_sinkDevice_positive);
+    UT_add_test( pSuite_panel, "TxAsyncSink_negative", test_hdmicec_hal_l1_hdmiCecTxAsync_sinkDevice_negative);
+    //UT_add_test( pSuite_panel, "addLogicalAddressWithAddressInUseSink", test_hdmicec_hal_l1_addLogicalAddressWithAddressInUse_sinkDevice);
     //UT_add_test( pSuiteHdmiDisConnected, "portDisconnectedSink", test_hdmicec_hal_l1_portDisconnected_sink);
 
-    UT_add_test( pSuiteNegative_stb, "getLogicalAddressSource_negative", test_hdmicec_hal_l1_getLogicalAddress_sourceDevice_negative);
-    UT_add_test( pSuiteNegative_stb, "hdmiCecTxSource_negative", test_hdmicec_hal_l1_hdmiCecTx_sourceDevice_negative);
-    UT_add_test( pSuiteNegative_stb, "hdmiCecTxAsyncSource_negative", test_hdmicec_hal_l1_hdmiCecTxAsync_sourceDevice_negative);
-    UT_add_test( pSuiteLAUS, "open_logical_address_unavailable_source", test_hdmicec_hal_l1_open_logical_address_unavailable_source);
-    UT_add_test( pSuitePositive_stb, "getLogicalAddressSource_Positive", test_hdmicec_hal_l1_getLogicalAddress_sourceDevice_positive);
-    UT_add_test( pSuitePositive_stb, "hdmiCecTxSource_Positive", test_hdmicec_hal_l1_hdmiCecTx_sourceDevice_positive);
-    UT_add_test( pSuitePositive_stb, "hdmiCecTxAsyncSource_Positive", test_hdmicec_hal_l1_hdmiCecTxAsync_sourceDevice_positive);
+    UT_add_test( pSuite_stb, "getLogicalAddressSource_Positive", test_hdmicec_hal_l1_getLogicalAddress_sourceDevice_positive);
+    UT_add_test( pSuite_stb, "getLogicalAddressSource_negative", test_hdmicec_hal_l1_getLogicalAddress_sourceDevice_negative);
+    UT_add_test( pSuite_stb, "TxSource_Positive", test_hdmicec_hal_l1_hdmiCecTx_sourceDevice_positive);
+    UT_add_test( pSuite_stb, "TxSource_negative", test_hdmicec_hal_l1_hdmiCecTx_sourceDevice_negative);
+    UT_add_test( pSuite_stb, "TxAsyncSource_Positive", test_hdmicec_hal_l1_hdmiCecTxAsync_sourceDevice_positive);
+    UT_add_test( pSuite_stb, "TxAsyncSource_negative", test_hdmicec_hal_l1_hdmiCecTxAsync_sourceDevice_negative);
+    //UT_add_test( pSuite_stb, "open_logical_address_unavailable_source", test_hdmicec_hal_l1_open_logical_address_unavailable_source);
     //UT_add_test( pSuiteHdmiDisConnected, "portDisconnectedSource", test_hdmicec_hal_l1_portDisconnected_source);
-
-    UT_add_test( pSuitePositive, "open_Positive", test_hdmicec_hal_l1_open_positive);
-    UT_add_test( pSuitePositive, "close_Positive", test_hdmicec_hal_l1_close_positive);
-    UT_add_test( pSuitePositive, "getPhysicalAddress_Positive", test_hdmicec_hal_l1_getPhysicalAddress_positive);
-
-    UT_add_test( pSuitePositive, "setRxCallback_Positive", test_hdmicec_hal_l1_setRxCallback_positive);
-    UT_add_test( pSuitePositive, "setTxCallback_Positive", test_hdmicec_hal_l1_setTxCallback_positive);
 
     return 0;
 }

--- a/src/test_l1_hdmi_cec_driver.c
+++ b/src/test_l1_hdmi_cec_driver.c
@@ -70,21 +70,18 @@
 #include "ut_log.h"
 #include "hdmi_cec_driver.h"
 
-//Set the MACRO for the stb platforms
-//#define __UT_STB__ 1
-
-#ifdef __UT_STB__
-    /**
+/**
      * Set CEC play back logical address here
      * More about CEC logical address read the documentation here
      * https://www.kernel.org/doc/html/v4.11/media/kapi/cec-core.html
      * https://elinux.org/CEC_(Consumer_Electronics_Control)_over_HDMI
-     */
-    #define DEFAULT_LOGICAL_ADDRESS 3
-#else
-    /// Set the CEC sink (Display device) logical address here
-    #define DEFAULT_LOGICAL_ADDRESS 0
-#endif
+*/
+#define DEFAULT_LOGICAL_ADDRESS_STB 3
+
+
+/// Set the CEC sink (Display device) logical address here
+#define DEFAULT_LOGICAL_ADDRESS_PANEL 0
+
 
 static int gTestGroup = 1;
 static int gTestID = 1;
@@ -141,15 +138,23 @@ struct timespec cec_tsl1_g;
 void DriverReceiveCallback(int handle, void *callbackData, unsigned char *buf, int len)
 {
     UT_LOG ("\nBuffer generated: %x length: %d\n",buf, len);
-    UT_ASSERT_TRUE(len>0); 
-    UT_ASSERT_TRUE(handle!=0);
-    UT_ASSERT_PTR_NOT_NULL((bool)(callbackData));
-    UT_ASSERT_PTR_NOT_NULL((bool)(buf));
-    //UT_ASSERT_TRUE( (unsigned long long)callbackData== (unsigned long long)0xDEADBEEF);
-    cec_isPingTriggeredl1_g = true;
-    UT_LOG ("\nCall back data generated is \n");
-    for (int index=0; index < len; index++) {
-        UT_LOG ("buf at index : %d is %x", index, buf[index]);
+    if((handle!=0) && (callbackData !=NULL) && (len>0)) {
+            cec_isPingTriggeredl1_g = true;
+            UT_LOG ("\nCall back data generated is \n");
+            for (int index=0; index < len; index++) {
+                    UT_LOG ("buf at index : %d is %x", index, buf[index]);
+            }
+    }
+    else {
+        if (handle == 0) {
+            UT_FAIL ("Error: Invalid handle.\n");
+        }
+        if (callbackData == NULL) {
+            UT_FAIL ("Error: Null callback data.\n");
+        }
+        if (len <= 0) {
+            UT_FAIL ("Error: Invalid length.\n");
+        }
     }
 }
 
@@ -162,10 +167,10 @@ void DriverReceiveCallback(int handle, void *callbackData, unsigned char *buf, i
  */
 void DriverTransmitCallback(int handle, void *callbackData, int result)
 {
-    UT_ASSERT_TRUE(handle!=0);
-    UT_ASSERT_PTR_NOT_NULL((bool)(!callbackData));
-    //UT_ASSERT_TRUE( (unsigned long long)callbackData== (unsigned long long)0xDEADBEEF);
-    UT_LOG ("\ncallbackData returned: %x result: %d\n",callbackData, result);
+   if((handle!=0) && (callbackData !=NULL)) {
+           //UT_ASSERT_TRUE_FATAL( (unsigned long long)callbackData== (unsigned long long)0xDEADBEEF);
+           UT_LOG ("\ncallbackData returned: %x result: %d\n",callbackData, result);
+   }
 }
 
 /**
@@ -241,16 +246,16 @@ void test_hdmicec_hal_l1_open_negative( void )
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     //Check Null even before calling the positive case
     result = HdmiCecOpen( NULL );
-    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { UT_FAIL ("open failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { UT_FAIL_FATAL ("open failed"); }
 
     result = HdmiCecOpen( &handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("open failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("open failed"); }
     
     result = HdmiCecOpen( &handle );
-    if (HDMI_CEC_IO_ALREADY_OPEN != result) { HDMICEC_TERM(); UT_FAIL ("open failed"); }
+    if (HDMI_CEC_IO_ALREADY_OPEN != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("open failed"); }
 
     result = HdmiCecClose( handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("close failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("close failed"); }
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
 }
@@ -288,10 +293,10 @@ void test_hdmicec_hal_l1_open_positive( void )
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     
     result = HdmiCecOpen( &handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("open failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("open failed"); }
 
     result = HdmiCecClose( handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("close failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("close failed"); }
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
 }
@@ -328,14 +333,14 @@ void test_hdmicec_hal_l1_open_logical_address_unavailable_source ( void )
     UT_LOG ("\nPlease connect other 4 cec enabled playback devices to the cec network. \
                   Please enter any key to continue"); getchar ();
     result = HdmiCecOpen( &handle );
-    if (HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE != result) { UT_FAIL ("open failed"); }
+    if (HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE != result) { UT_FAIL_FATAL ("open failed"); }
     
     //The above open is failed handle should be null
-    UT_ASSERT_TRUE(handle!=0);
+    UT_ASSERT_TRUE_FATAL(handle!=0);
 
      //Here handle = 0 since open failed and close should fail.
     result = HdmiCecClose( handle );
-    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { UT_FAIL ("close failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { UT_FAIL_FATAL ("close failed"); }
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
 }
@@ -371,19 +376,19 @@ void test_hdmicec_hal_l1_close_negative( void )
 
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     result = HdmiCecClose( handle );
-    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL ("close failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL_FATAL ("close failed"); }
 
     result = HdmiCecOpen( &handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("open failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("open failed"); }
 
     result = HdmiCecClose( 0 );
-    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_TERM(); UT_FAIL ("close failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("close failed"); }
 
     result = HdmiCecClose( handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("close failed"); }  
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("close failed"); }
 
     result = HdmiCecClose( handle );
-    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL ("close failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL_FATAL ("close failed"); }
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
 
@@ -418,16 +423,16 @@ void test_hdmicec_hal_l1_close_positive( void )
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
     result = HdmiCecOpen( &handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("open failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("open failed"); }
 
     result = HdmiCecClose( handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("close failed"); }  
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("close failed"); }
 
     result = HdmiCecOpen( &handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("open failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("open failed"); }
 
     result = HdmiCecClose( handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("close failed"); } 
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("close failed"); }
 
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
@@ -467,35 +472,35 @@ void test_hdmicec_hal_l1_getPhysicalAddress_negative( void )
 
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     result = HdmiCecGetPhysicalAddress(handle, &physicalAddress);
-    if (HDMI_CEC_IO_SUCCESS  != result) { UT_FAIL ("HdmiCecGetPhysicalAddress failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecGetPhysicalAddress failed"); }
 
 
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecGetPhysicalAddress(0, &physicalAddress);
-    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetPhysicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetPhysicalAddress failed"); }
 
     result = HdmiCecGetPhysicalAddress(handle, NULL);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetPhysicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetPhysicalAddress failed"); }
 
 
     result = HdmiCecGetPhysicalAddress(handle, &physicalAddress);
-    if (HDMI_CEC_IO_SUCCESS  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetPhysicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetPhysicalAddress failed"); }
     unsigned int maxVal = (((0x04 &0xF0 ) << 20)|( (0x04 &0x0F ) << 16) |((0x04 & 0xF0) << 4)  | (0x04 & 0x0F));
     //Max possible physical address is 4.4.4.4
     if (physicalAddress>maxVal) {
-        HDMICEC_TERM(); UT_FAIL ("physicalAddress miss match failed");
+        HDMICEC_TERM(); UT_FAIL_FATAL ("physicalAddress miss match failed");
     }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("close failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("close failed"); }
 
     //Calling API after close,
     result = HdmiCecGetPhysicalAddress(handle, &physicalAddress);
-    if (HDMI_CEC_IO_SUCCESS  != result) { UT_FAIL ("HdmiCecGetPhysicalAddress failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL_FATAL ("HdmiCecGetPhysicalAddress failed"); }
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
 
@@ -531,15 +536,17 @@ void test_hdmicec_hal_l1_getPhysicalAddress_positive( void )
 
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecGetPhysicalAddress(handle, &physicalAddress);
-    if (HDMI_CEC_IO_SUCCESS  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetPhysicalAddress failed"); }
-    UT_ASSERT_TRUE(physicalAddress!=0xffff);
+    if (HDMI_CEC_IO_SUCCESS  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetPhysicalAddress failed"); }
+    if(physicalAddress == 0xffff){
+	    UT_FAIL("Invalid physicalAddress ");
+    }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("close failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("close failed"); }
 
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
@@ -583,30 +590,30 @@ void test_hdmicec_hal_l1_addLogicalAddress_sinkDevice_negative( void )
 
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
 
 
     result = HdmiCecAddLogicalAddress( 0, logicalAddress );
-    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecAddLogicalAddress( handle, -1 );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecAddLogicalAddress( handle, 0x3 );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecAddLogicalAddress( handle, 0xF );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecClose( handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("close failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("close failed"); }
 
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
 }
@@ -647,14 +654,14 @@ void test_hdmicec_hal_l1_addLogicalAddress_sinkDevice_positive( void )
 
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
 
-    logicalAddress = DEFAULT_LOGICAL_ADDRESS;
+    logicalAddress = DEFAULT_LOGICAL_ADDRESS_PANEL;
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecClose( handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("close failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("close failed"); }
 
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
@@ -698,33 +705,33 @@ void test_hdmicec_hal_l1_addLogicalAddress_sourceDevice( void )
 
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_NOT_OPENED  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecAddLogicalAddress( 0, logicalAddress );
-    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecAddLogicalAddress( handle, -1 );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecAddLogicalAddress( handle, 0x3 );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecAddLogicalAddress( handle, 0xF );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
 
-    logicalAddress = DEFAULT_LOGICAL_ADDRESS;
+    logicalAddress = DEFAULT_LOGICAL_ADDRESS_STB;
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecClose( handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("Close failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("Close failed"); }
 
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
 }
@@ -763,13 +770,13 @@ void test_hdmicec_hal_l1_addLogicalAddressWithAddressInUse_sinkDevice( void )
     UT_LOG ("\nPlease connect another CEC enabled sink device to the device. Please enter any key to continue"); getchar ();
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
     
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_LOGICALADDRESS_UNAVAILABLE != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecClose( handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("close failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("close failed"); }
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
 }
@@ -809,46 +816,46 @@ void test_hdmicec_hal_l1_removeLogicalAddress_sinkDevice_negative( void )
 {
     int result;
     int handle = 0;
-    int logicalAddress = DEFAULT_LOGICAL_ADDRESS;
+    int logicalAddress = DEFAULT_LOGICAL_ADDRESS_PANEL;
     gTestID = 12;
 
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     result = HdmiCecRemoveLogicalAddress(handle, logicalAddress );
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecOpen(&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecRemoveLogicalAddress( 0, logicalAddress );
-    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecRemoveLogicalAddress( handle, 0xF );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecRemoveLogicalAddress( handle,  -1 );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecRemoveLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecRemoveLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_ALREADY_REMOVED != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_ALREADY_REMOVED != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecRemoveLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecRemoveLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_ALREADY_REMOVED != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_ALREADY_REMOVED != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecClose(handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("close failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("close failed"); }
 
     result = HdmiCecRemoveLogicalAddress(handle, logicalAddress );
-    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
 }
@@ -879,23 +886,23 @@ void test_hdmicec_hal_l1_removeLogicalAddress_sinkDevice_positive( void )
 {
     int result;
     int handle = 0;
-    int logicalAddress = DEFAULT_LOGICAL_ADDRESS;
+    int logicalAddress = DEFAULT_LOGICAL_ADDRESS_PANEL;
     gTestID = 13;
 
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
     result = HdmiCecOpen(&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecRemoveLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecClose(handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("close failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("close failed"); }
 
 }
 
@@ -930,36 +937,36 @@ void test_hdmicec_hal_l1_removeLogicalAddress_sourceDevice( void )
 {
     int result;
     int handle = 0;
-    int logicalAddress = DEFAULT_LOGICAL_ADDRESS;
+    int logicalAddress = DEFAULT_LOGICAL_ADDRESS_STB;
     gTestID = 14;
 
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     result = HdmiCecRemoveLogicalAddress(handle, logicalAddress );
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecOpen(&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecRemoveLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecRemoveLogicalAddress( 0, logicalAddress );
-    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
 
     logicalAddress = 0xF;
     result = HdmiCecRemoveLogicalAddress( handle, 0xF );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
 
     logicalAddress = -1;
     result = HdmiCecRemoveLogicalAddress( handle, -1 );
-    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecClose(handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("close failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("close failed"); }
 
     result = HdmiCecRemoveLogicalAddress(handle, logicalAddress );
-    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
 }
@@ -1004,43 +1011,49 @@ void test_hdmicec_hal_l1_getLogicalAddress_sinkDevice_negative( void )
 
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
 
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecGetLogicalAddress(0, &logicalAddress);
-    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
 
     result = HdmiCecGetLogicalAddress(handle, NULL);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
 
     result = HdmiCecGetLogicalAddress(handle, &logicalAddressCrossCheck);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
-    UT_ASSERT_TRUE( (int)0xF== logicalAddressCrossCheck);
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if((int)0xF!= logicalAddressCrossCheck){
+	    UT_FAIL("Invalid logicalAddress ");
+    }
 
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
 
     result = HdmiCecGetLogicalAddress(handle, &logicalAddressCrossCheck);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
-    UT_ASSERT_TRUE( logicalAddress== logicalAddressCrossCheck);
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if(logicalAddress != logicalAddressCrossCheck){
+	    UT_FAIL("logicalAddress and logicalAddressCrossCheck are not same");
+    }
 
     result = HdmiCecRemoveLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
 
     result = HdmiCecGetLogicalAddress(handle, &logicalAddressCrossCheck);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
-    UT_ASSERT_TRUE( (int)0xF== logicalAddressCrossCheck);
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if((int)0xF!= logicalAddressCrossCheck){
+	    UT_FAIL("Invalid logicalAddress");
+    }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
 
     //Calling API after close, should give invalid argument
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
 
@@ -1062,8 +1075,9 @@ void test_hdmicec_hal_l1_getLogicalAddress_sinkDevice_negative( void )
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|---------|----------|--------------|-----|
  * |01|Call HdmiCecOpen() - open interface | handle | HDMI_CEC_IO_SUCCESS| Should Pass |
- * |02|Call HdmiCecGetLogicalAddress() - call API with valid arguments; should return the logical address added by the caller | handle, &logicalAddress | HDMI_CEC_IO_SUCCESS| Should Pass |
- * |03|Call HdmiCecClose () - close interface | handle | HDMI_CEC_IO_SUCCESS| Should Pass |
+ * |02|Call HdmiCecAddLogicalAddress() - add logical address
+ * |03|Call HdmiCecGetLogicalAddress() - call API with valid arguments; should return the logical address added by the caller | handle, &logicalAddress | HDMI_CEC_IO_SUCCESS| Should Pass |
+ * |04|Call HdmiCecClose () - close interface | handle | HDMI_CEC_IO_SUCCESS| Should Pass |
  */
 void test_hdmicec_hal_l1_getLogicalAddress_sinkDevice_positive ( void )
 {
@@ -1077,21 +1091,23 @@ void test_hdmicec_hal_l1_getLogicalAddress_sinkDevice_positive ( void )
 
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecAddLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
 
     result = HdmiCecGetLogicalAddress(handle, &logicalAddressCrossCheck);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
-    UT_ASSERT_TRUE( logicalAddress== logicalAddressCrossCheck);
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if(logicalAddress != logicalAddressCrossCheck){
+             UT_FAIL("logicalAddress and logicalAddressCrossCheck are not same");
+     }
 
     result = HdmiCecRemoveLogicalAddress( handle, logicalAddress );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecRemoveLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecRemoveLogicalAddress failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
 
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
@@ -1119,7 +1135,7 @@ void test_hdmicec_hal_l1_getLogicalAddress_sinkDevice_positive ( void )
  * |02|Call HdmiCecOpen() - open interface | handle | HDMI_CEC_IO_SUCCESS| Should Pass |
  * |03|Call HdmiCecGetLogicalAddress() - call the api, with invalid handle | handle=0, &logicalAddress | HDMI_CEC_IO_INVALID_HANDLE| Should Pass |
  * |04|Call HdmiCecGetLogicalAddress() - call API with invalid logical address | handle, &logicalAddress=NULL  | HDMI_CEC_IO_INVALID_ARGUMENT| Should Pass |
- * |05|Call HdmiCecGetLogicalAddress() - call API with valid arguments in source devices should return a valid logical address between 0x00 and 0x0F, excluding both the values. | handle, &logicalAddress | HDMI_CEC_IO_SUCCESS| Should Pass |
+ * |05|Call HdmiCecGetLogicalAddress() - call API with valid arguments in source devices should return a valid logical address between 0x01 and 0x0F, excluding both the values. | handle, &logicalAddress | HDMI_CEC_IO_SUCCESS| Should Pass |
  * |06|Call HdmiCecClose () - close interface | handle | HDMI_CEC_IO_SUCCESS| Should Pass |
  * |07|Call HdmiCecGetLogicalAddress()  - call the API after module is closed | handle, &logicalAddress | HDMI_CEC_IO_NOT_OPENED| Should Pass |
  */
@@ -1132,29 +1148,31 @@ void test_hdmicec_hal_l1_getLogicalAddress_sourceDevice_negative( void )
 
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     result = HdmiCecGetLogicalAddress(handle,  &logicalAddress);
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
 
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecGetLogicalAddress(0,  &logicalAddress);
-    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
 
     result = HdmiCecGetLogicalAddress(handle, NULL);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
 
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
-    UT_ASSERT_TRUE(logicalAddress>0x0E && logicalAddress<0x01);
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if(logicalAddress<=0 || logicalAddress>0x0B || (logicalAddress==0x0F)){
+	    UT_FAIL("Invalid logicalAddress");
+    }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
 
     //Calling API after close, should give invalid argument
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
 
@@ -1190,15 +1208,17 @@ void test_hdmicec_hal_l1_getLogicalAddress_sourceDevice_positive( void )
 
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
-    UT_ASSERT_TRUE(logicalAddress>0x0E && logicalAddress<0x01);
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+    if(logicalAddress<=0 || logicalAddress>0x0B || (logicalAddress==0x0F)){
+            UT_LOG("Invalid logicalAddress 0x%x\n",logicalAddress);
+    }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
 }
 
 /**
@@ -1209,8 +1229,7 @@ void test_hdmicec_hal_l1_getLogicalAddress_sourceDevice_positive( void )
  * **Test Case ID:** 019@n
  * 
  * 
- * **Pre-Conditions:**@n
- * Connect at least one CEC enabled device
+ * **Pre-Conditions:**None@n
  *
  * **Dependencies:** None@n
  * **User Interaction:** None
@@ -1229,32 +1248,30 @@ void test_hdmicec_hal_l1_setRxCallback_negative ( void )
 {
     int result;
     int handle = 0;
-    gTestID = 20;
+    gTestID = 19;
 
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
     //Calling API before open, should pass
     result = HdmiCecSetRxCallback(handle, DriverReceiveCallback, (void*)0xDEADBEEF);
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL ("HdmiCecSetRxCallback failed"); } 
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecSetRxCallback failed"); }
 
     /* Positive result */
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecSetRxCallback(0, DriverReceiveCallback, (void*)0xDEADBEEF);
-    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetRxCallback failed"); } 
+    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetRxCallback failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
 
     //Calling API after close, should return success
     result = HdmiCecSetRxCallback(handle, DriverReceiveCallback, 0);
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL ("HdmiCecSetRxCallback failed"); } 
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecSetRxCallback failed"); }
 
-    HdmiCecSetRxCallback(0, DriverReceiveCallback, 0);
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL ("HdmiCecSetRxCallback failed"); } 
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
 
@@ -1266,8 +1283,7 @@ void test_hdmicec_hal_l1_setRxCallback_negative ( void )
  * **Test Case ID:** 020@n
  * 
  * 
- * **Pre-Conditions:**@n
- * Connect at least one CEC enabled device
+ * **Pre-Conditions:**None@n
  *
  * **Dependencies:** None@n
  * **User Interaction:** None
@@ -1276,18 +1292,15 @@ void test_hdmicec_hal_l1_setRxCallback_negative ( void )
  * |Variation / Step|Description|Test Data|Expected Result|Notes|
  * |:--:|---------|----------|--------------|-----|
  * |01|Call HdmiCecOpen() - open interface | handle | HDMI_CEC_IO_SUCCESS| Should Pass |
- * |02|Call HdmiCecAddLogicalAddress() - call add logical address with valid arguments | handle, logicalAddress | HDMI_CEC_IO_SUCCESS| Should Pass |
- * |03|Call HdmiCecGetLogicalAddress() - call get logical address with valid arguments | handle, &logicalAddress | HDMI_CEC_IO_SUCCESS| Should Pass |
- * |04|Call HdmiCecSetRxCallback() - set RX Call back with valid parameters | handle, DriverReceiveCallback, data=0xDEADBEEF | HDMI_CEC_IO_SUCCESS| Should Pass |
- * |05|Call HdmiCecSetRxCallback() - unset the RX Call back with NULL params| handle, DriverReceiveCallback=NULL, data=0 | HDMI_CEC_IO_SUCCESS| Should Pass |
- * |06|Call HdmiCecClose () - close interface | handle | HDMI_CEC_IO_SUCCESS| Should Pass |
+ * |02|Call HdmiCecSetRxCallback() - set RX Call back with valid parameters | handle, DriverReceiveCallback, data=0xDEADBEEF | HDMI_CEC_IO_SUCCESS| Should Pass |
+ * |03|Call HdmiCecSetRxCallback()  - set RX Call back with NULL callback | handle, DriverTransmitCallback, data address | HDMI_CEC_IO_SUCCESS| Should Pass |
+ * |04|Call HdmiCecClose () - close interface | handle | HDMI_CEC_IO_SUCCESS| Should Pass |
  * 
  */
 void test_hdmicec_hal_l1_setRxCallback_positive( void )
 {
     int result;
     int handle = 0;
-    int logicalAddress = 0;
     gTestID = 20;
 
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
@@ -1295,40 +1308,18 @@ void test_hdmicec_hal_l1_setRxCallback_positive( void )
     /* Positive result */
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
-
-    logicalAddress = DEFAULT_LOGICAL_ADDRESS;
-
-    //Set logical address for TV
-    //logicalAddress = 0;
-    result = HdmiCecAddLogicalAddress(handle, logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) {
-        /*Cleanup before exiting */
-        result = HdmiCecClose (handle);
-        if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("HdmiCecClose failed"); }
-        UT_FAIL ("HdmiCecAddLogicalAddress failed");
-    }
-
-    //Get logical address for STB
-    result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
-
-    //Using NULL callback
-    result = HdmiCecSetRxCallback(0, DriverReceiveCallback, 0);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetRxCallback failed"); }
+    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
 
     /* Positive result */
     result = HdmiCecSetRxCallback(handle, DriverReceiveCallback, (void*)0xDEADBEEF);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetRxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetRxCallback failed"); }
 
-
-    //Using NULL callback
-    result = HdmiCecSetRxCallback(handle, NULL, 0);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("ChHdmiCecSetRxCallbackeck failed"); }
+    result = HdmiCecSetRxCallback( handle, NULL, (void*)0xDEADBEEF );
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetTxCallback failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
 
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
@@ -1341,8 +1332,7 @@ void test_hdmicec_hal_l1_setRxCallback_positive( void )
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 021@n
  * 
- * **Pre-Conditions:**@n
- * None
+ * **Pre-Conditions:**None@n
  * 
  * **Dependencies:** None@n
  * **User Interaction:** None
@@ -1365,20 +1355,20 @@ void test_hdmicec_hal_l1_setTxCallback_negative( void )
 
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     result = HdmiCecSetTxCallback( handle, DriverTransmitCallback, (void*)0xDEADBEEF );
-    if (HDMI_CEC_IO_NOT_OPENED  != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetTxCallback failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED  != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetTxCallback failed"); }
 
     result = HdmiCecOpen ( &handle );
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecSetTxCallback(0, NULL, (void*)0xDEADBEEF);
-    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetTxCallback failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetTxCallback failed"); }
     
     result = HdmiCecClose( handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
 
     result = HdmiCecSetTxCallback( handle, DriverTransmitCallback, (void*)0xDEADBEEF );
-    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL ("HdmiCecSetTxCallback failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED  != result) { UT_FAIL_FATAL ("HdmiCecSetTxCallback failed"); }
 
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
@@ -1389,8 +1379,7 @@ void test_hdmicec_hal_l1_setTxCallback_negative( void )
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 022@n
  * 
- * **Pre-Conditions:**@n
- * None
+ * **Pre-Conditions:**None@n
  * 
  * **Dependencies:** None@n
  * **User Interaction:** None
@@ -1400,7 +1389,7 @@ void test_hdmicec_hal_l1_setTxCallback_negative( void )
  * |:--:|---------|----------|--------------|-----|
  * |01|Call HdmiCecOpen() - open interface | handle | HDMI_CEC_IO_SUCCESS| Should Pass |
  * |02|Call HdmiCecSetTxCallback() - set TX Call back with valid parameters | handle, DriverTransmitCallback, data address | HDMI_CEC_IO_SUCCESS| Should Pass |
- * |03|Call HdmiCecSetTxCallback()  - set RX Call back with NULL callback | handle, DriverTransmitCallback, data address | HDMI_CEC_IO_SUCCESS| Should Pass |
+ * |03|Call HdmiCecSetTxCallback()  - set TX Call back with NULL callback | handle, DriverTransmitCallback, data address | HDMI_CEC_IO_SUCCESS| Should Pass |
  * |04|Call HdmiCecClose () - close interface | handle=hdmiHandle | HDMI_CEC_IO_SUCCESS| Should Pass |
  * 
  */
@@ -1415,20 +1404,19 @@ void test_hdmicec_hal_l1_setTxCallback_positive( void )
 
     result = HdmiCecOpen ( &handle );
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
 
     result = HdmiCecSetTxCallback( handle, DriverTransmitCallback, (void*)0xDEADBEEF );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetTxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetTxCallback failed"); }
 
     result = HdmiCecSetTxCallback( handle, NULL, (void*)0xDEADBEEF );
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetTxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetTxCallback failed"); }
 
     result = HdmiCecClose( handle );
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
 
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
-
 
 /**
  * @brief Ensure HdmiCecTx() returns correct error codes, during all of this API's invocation scenarios
@@ -1441,8 +1429,7 @@ void test_hdmicec_hal_l1_setTxCallback_positive( void )
  * **Test Group ID:** Basic: 01@n
  * **Test Case ID:** 023@n
  * 
- * **Pre-Conditions:**@n
- * Connect at least one CEC enabled device.
+ * **Pre-Conditions:** None@n
  * 
  * **Dependencies:** None@n
  * **User Interaction:** None
@@ -1459,10 +1446,8 @@ void test_hdmicec_hal_l1_setTxCallback_positive( void )
  * |07|Call HdmiCecTx() - invoke send cec message with invalid buffer | handle, buf=NULL, len, &ret  | HDMI_CEC_IO_INVALID_ARGUMENT| Should Pass |
  * |08|Call HdmiCecTx() - invoke send cec message with invalid handle | handle=0, buf, len, &ret  | HDMI_CEC_IO_INVALID_HANDLE| Should Pass |
  * |09|Call HdmiCecTx() - invoke send cec message with invalid buffer length | handle, buf, len=INT_MIN, &ret  | HDMI_CEC_IO_INVALID_ARGUMENT| Should Pass |
- * |10|Call HdmiCecTx() - send the cec message with valid arguments after module initialization | handle, buf, len, &ret | HDMI_CEC_IO_SUCCESS and ret=HDMI_CEC_IO_SENT_AND_ACKD| Should Pass |
- * |11|Call HdmiCecTx() - back to back send to ensure it is passing | handle, buf, len. &ret | HDMI_CEC_IO_SUCCESS and ret=HDMI_CEC_IO_SENT_AND_ACKD | Should Pass | 
- * |12|Call HdmiCecClose() - close interface | handle=hdmiHandle | HDMI_CEC_IO_SUCCESS| Should Pass |
- * |13|Call HdmiCecTx()  -  invoke send cec message once module is closed | handle, buf, len, &ret | HDMI_CEC_IO_NOT_OPENED| Should Pass |
+ * |10|Call HdmiCecClose() - close interface | handle=hdmiHandle | HDMI_CEC_IO_SUCCESS| Should Pass |
+ * |11|Call HdmiCecTx()  -  invoke send cec message once module is closed | handle, buf, len, &ret | HDMI_CEC_IO_NOT_OPENED| Should Pass |
  */
 void test_hdmicec_hal_l1_hdmiCecTx_sinkDevice_negative( void )
 {
@@ -1481,71 +1466,52 @@ void test_hdmicec_hal_l1_hdmiCecTx_sinkDevice_negative( void )
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     //Calling API before open, should give invalid argument
     result = HdmiCecTx(handle, buf, len, &ret);
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecTx failed"); }
 
     /* Positive result */
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
 
-    logicalAddress = DEFAULT_LOGICAL_ADDRESS;
+    logicalAddress = DEFAULT_LOGICAL_ADDRESS_PANEL;
 
     result = HdmiCecTx(handle, buf, len, &ret);
-    if (HDMI_CEC_IO_SENT_FAILED != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SENT_FAILED != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
 
     //Set logical address for TV
     //logicalAddress = 0;
     result = HdmiCecAddLogicalAddress(handle, logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) {
-        /*Cleanup before exiting */
-        result = HdmiCecClose (handle);
-        if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("HdmiCecAddLogicalAddress failed"); }
-        UT_FAIL ("HdmiCecAddLogicalAddress failed");
-    }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
 
     buf[0] = 0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     //Get logical address
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
 
     /* Invalid input */
     result = HdmiCecTx(handle, buf, len, NULL);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
 
     /* Invalid input */
     result = HdmiCecTx(handle, NULL, len, &ret);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
 
     /* Invalid input */
     result = HdmiCecTx(0, buf, len, &ret);
-    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
 
     /* Invalid input */
     result = HdmiCecTx(handle, buf, INT_MIN, &ret);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
-
-    UT_LOG ("\n hdmicec logicalAddress: 0x%x\n", (logicalAddress&0xFF)<<4);
-    buf[0] = ((logicalAddress&0xFF)<<4)|0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
-
-    /* Positive result */
-    result = HdmiCecTx(handle, buf, len, &ret);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
-    if (HDMI_CEC_IO_SENT_AND_ACKD != ret) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
-
-    buf [1] = CEC_DEVICE_VENDOR_ID;
-    /*Back to back send and ensure send is not failed.*/
-    result = HdmiCecTx(handle, buf, len, &ret);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
-    if (HDMI_CEC_IO_SENT_AND_ACKD != ret) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
 
     //Calling API after close, should give invalid argument
     result = HdmiCecTx(handle, buf, len, &ret);
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecTx failed"); }
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
 
@@ -1591,25 +1557,20 @@ void test_hdmicec_hal_l1_hdmiCecTx_sinkDevice_positive( void )
     /* Positive result */
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
 
-    logicalAddress = DEFAULT_LOGICAL_ADDRESS;
+    logicalAddress = DEFAULT_LOGICAL_ADDRESS_PANEL;
 
     //Set logical address for TV
     //logicalAddress = 0;
     result = HdmiCecAddLogicalAddress(handle, logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) {
-        /*Cleanup before exiting */
-        result = HdmiCecClose (handle);
-        if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("HdmiCecClose failed"); }
-        UT_FAIL ("HdmiCecAddLogicalAddress failed");
-    }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
 
     buf[0] = 0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     //Get logical address
     result = HdmiCecGetLogicalAddress(handle,  &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
 
 
     UT_LOG ("\n hdmicec logicalAddress: 0x%x\n", (logicalAddress&0xFF)<<4);
@@ -1617,15 +1578,16 @@ void test_hdmicec_hal_l1_hdmiCecTx_sinkDevice_positive( void )
 
     /* Positive result */
     result = HdmiCecTx(handle, buf, len, &ret);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
-    if (HDMI_CEC_IO_SENT_AND_ACKD != ret) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SENT_AND_ACKD != ret) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
 
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
+
 
 /**
  * @brief Ensure HdmiCecTx() returns correct error codes, during the negative API's invocation scenarios
@@ -1654,10 +1616,8 @@ void test_hdmicec_hal_l1_hdmiCecTx_sinkDevice_positive( void )
  * |05|Call HdmiCecTx() - invoke send cec message with invalid buffer | handle, buf=NULL, len, &ret  | HDMI_CEC_IO_INVALID_ARGUMENT| Should Pass |
  * |06|Call HdmiCecTx() - invoke send cec message with invalid handle | handle=0, buf, len, &ret  | HDMI_CEC_IO_INVALID_HANDLE| Should Pass |
  * |07|Call HdmiCecTx() - invoke send cec message with invalid buffer length | handle, buf, len=INT_MIN, &ret  | HDMI_CEC_IO_INVALID_ARGUMENT| Should Pass |
- * |08|Call HdmiCecTx() - send the cec message with valid arguments after module initialization | handle, buf, len, &ret | HDMI_CEC_IO_SUCCESS and ret=HDMI_CEC_IO_SENT_AND_ACKD| Should Pass |
- * |09|Call HdmiCecTx() - back to back send to ensure it is passing | handle, buf, len. &ret | HDMI_CEC_IO_SUCCESS and ret=HDMI_CEC_IO_SENT_AND_ACKD| Should Pass |
- * |10|Call HdmiCecClose() - close interface | handle=hdmiHandle | HDMI_CEC_IO_SUCCESS| Should Pass |
- * |11|Call HdmiCecTx()  -  invoke send cec message once module is closed | handle, buf, len, &ret | HDMI_CEC_IO_NOT_OPENED| Should Pass |
+ * |08|Call HdmiCecClose() - close interface | handle=hdmiHandle | HDMI_CEC_IO_SUCCESS| Should Pass |
+ * |09|Call HdmiCecTx()  -  invoke send cec message once module is closed | handle, buf, len, &ret | HDMI_CEC_IO_NOT_OPENED| Should Pass |
  */
 void test_hdmicec_hal_l1_hdmiCecTx_sourceDevice_negative( void )
 {
@@ -1673,58 +1633,44 @@ void test_hdmicec_hal_l1_hdmiCecTx_sourceDevice_negative( void )
     unsigned char buf[] = {0x3F, CEC_GET_CEC_VERSION};
 
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    //Calling API before open, should give invalid argument
+    //Calling API before open, should give not open error
     result = HdmiCecTx(handle, buf, len, &ret);
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecTx failed"); }
 
     /* Positive result */
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
 
     buf[0] = 0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     //Get logical address
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
 
     /* Invalid input */
     result = HdmiCecTx(handle, buf, len, NULL);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
 
     /* Invalid input */
     result = HdmiCecTx(handle, NULL, len, &ret);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
 
     /* Invalid input */
     result = HdmiCecTx(0, buf, len, &ret);
-    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
 
     /* Invalid input */
     result = HdmiCecTx(handle, buf, INT_MIN, &ret);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
-
-    UT_LOG ("\n hdmicec logicalAddress: 0x%x\n", (logicalAddress&0xFF)<<4);
-    buf[0] = ((logicalAddress&0xFF)<<4)|0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
-
-    /* Positive result */
-    result = HdmiCecTx(handle, buf, len, &ret);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
-    if (HDMI_CEC_IO_SENT_AND_ACKD != ret) { HDMICEC_TERM(); UT_FAIL ("Check failed"); }
-
-    buf [1] = CEC_DEVICE_VENDOR_ID;
-    /*Back to back send and ensure send is not failed*/
-    result = HdmiCecTx(handle, buf, len, &ret);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
-    if (HDMI_CEC_IO_SENT_AND_ACKD != ret) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
 
     //Calling API after close, should give invalid argument
     result = HdmiCecTx(handle, buf, len, &ret);
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecTx failed"); }
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
 
@@ -1768,97 +1714,25 @@ void test_hdmicec_hal_l1_hdmiCecTx_sourceDevice_positive( void )
     /* Positive result */
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
 
     buf[0] = 0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     //Get logical address
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
 
     UT_LOG ("\n hdmicec logicalAddress: 0x%x\n", (logicalAddress&0xFF)<<4);
     buf[0] = ((logicalAddress&0xFF)<<4)|0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     /* Positive result */
     result = HdmiCecTx(handle, buf, len, &ret);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
-    if (HDMI_CEC_IO_SENT_AND_ACKD != ret) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SENT_AND_ACKD != ret) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("HdmiCecClose failed"); }
-}
-
-/**
- * @brief This function will try to ping an unavailable logical address and ensure ACK error happens
- * 
- * **Test Group ID:** 02@n
- * **Test Case ID:** 027@n
- *
- *
- * *Pre-Conditions :** @n
- *  All of the device HDMI cable should be disconnected
- *
- **Dependencies :** N/A @n
- *
- * **Test Procedure :**@n
- * |Variation / Step|Description|Test Data|Expected Result|Notes|
- * |:--:|---------|----------|--------------|-----|
- * |01|Call `HdmiCecOpen()` - open interface | handle | HDMI_CEC_IO_SUCCESS| Should Pass |
- * |02|Call `HdmiCecSetRxCallback()` - set RX Call back with valid parameters | handle, DriverTransmitCallback, data address | HDMI_CEC_IO_SUCCESS| Should Pass |
- * |03|Call `HdmiCecAddLogicalAddress()` - Call add logical address with valid arguments | handle, logicalAddress | HDMI_CEC_IO_SUCCESS| Should Pass |
- * |04|Call `HdmiCecGetLogicalAddress()` - Call get logical address with valid arguments | handle, &logicalAddress | HDMI_CEC_IO_SUCCESS| Should Pass |
- * |05|Call `HdmiCecTx()` - Try to ping an unavailable logical address and ensure ACK error | handle, buf, len, &ret | HDMI_CEC_IO_SUCCESS| Should Pass |
- * |06|Call `HdmiCecSetRxCallback()` - unregister RX Call back | handle, cbfunc=NULL, data address | HDMI_CEC_IO_SUCCESS| Should Pass |
- * |07|Call `HdmiCecClose ()` - close interface | handle=hdmiHandle | HDMI_CEC_IO_SUCCESS| Should Pass |
- */
-void test_hdmicec_hal_l1_portDisconnected_sink( void )
-{
-    int result=0;
-    int ret=0;
-    int handle = 0;
-    int logicalAddress = 0;
-    unsigned char buf[] = {0x03};
-    gTestID = 27;
-
-    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
-    UT_LOG ("\nPlease disconnect All the HDMI ports. Please enter any key to continue"); getchar ();
-
-    /* Positive result */
-    result = HdmiCecOpen (&handle);
-    //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
-
-    /* Positive result */
-    result = HdmiCecSetRxCallback(handle, DriverReceiveCallback, (void*)0xDEADBEEF);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetRxCallback failed"); }
-
-    //Set logical address for TV.
-    logicalAddress = 0;
-    result = HdmiCecAddLogicalAddress(handle, logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) {
-        /*Cleanup before exiting */
-        result = HdmiCecClose (handle);
-        if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecClose failed"); }
-        HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed");
-    }
-
-    //Get logical address of the device
-    result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
-
-    result = HdmiCecTx(handle, buf, sizeof(buf), &ret);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
-    if (HDMI_CEC_IO_SENT_BUT_NOT_ACKD != ret) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
-
-    //Using NULL callback
-    result = HdmiCecSetRxCallback(handle, NULL, 0);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetRxCallback failed"); }
-
-    /*calling hdmicec_close should pass */
-    result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("HdmiCecClose failed"); }
-    UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
 }
 
 /**
@@ -1887,10 +1761,8 @@ void test_hdmicec_hal_l1_portDisconnected_sink( void )
  * |05|Call HdmiCecTxAsync() - call cec message send with invalid argument | handle, buf=NULL, len | HDMI_CEC_IO_INVALID_ARGUMENT| Should Pass |
  * |06|Call HdmiCecTxAsync() - call cec message send with invalid argument | handle=0, buf, len | HDMI_CEC_IO_INVALID_HANDLE| Should Pass |
  * |07|Call HdmiCecTxAsync() - call cec message send with invalid argument | handle, buf, len=INT_MIN | HDMI_CEC_IO_INVALID_ARGUMENT| Should Pass |
- * |08|Call HdmiCecTxAsync() - send the cec message after correct module initialization | handle, buf, len | HDMI_CEC_IO_SUCCESS| Should Pass |
- * |09|Call HdmiCecTxAsync() - back to back send to ensure it is passing | handle, buf, len | HDMI_CEC_IO_SUCCESS| Should Pass |
- * |10|Call HdmiCecClose () - close interface | handle=hdmiHandle | HDMI_CEC_IO_SUCCESS| Should Pass |
- * |11|Call HdmiCecTxAsync()  - call API after module is closed | handle, buf, len | HDMI_CEC_IO_NOT_OPENED| Should Pass |
+ * |08|Call HdmiCecClose () - close interface | handle=hdmiHandle | HDMI_CEC_IO_SUCCESS| Should Pass |
+ * |09|Call HdmiCecTxAsync()  - call API after module is closed | handle, buf, len | HDMI_CEC_IO_NOT_OPENED| Should Pass |
  */
 void test_hdmicec_hal_l1_hdmiCecTxAsync_sinkDevice_negative( void )
 {
@@ -1907,67 +1779,55 @@ void test_hdmicec_hal_l1_hdmiCecTxAsync_sinkDevice_negative( void )
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     //Calling API before open, should give invalid argument
     result = HdmiCecTxAsync(handle, buf, len); //Code crash here
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecTxAsync failed"); }
 
     /* Positive result */
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
 
     /* Positive result */
     result = HdmiCecSetTxCallback(handle, DriverTransmitCallback, 0);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetTxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetTxCallback failed"); }
 
     //Set logical address for TV
-    logicalAddress = DEFAULT_LOGICAL_ADDRESS;
+    logicalAddress = DEFAULT_LOGICAL_ADDRESS_PANEL;
 
     result = HdmiCecTxAsync(handle, buf, len);
-    if (HDMI_CEC_IO_SENT_FAILED != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_SENT_FAILED != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTxAsync failed"); }
 
     result = HdmiCecAddLogicalAddress(handle, logicalAddress);
     if (HDMI_CEC_IO_SUCCESS != result) {
-        /*Cleanup before exiting */
-        result = HdmiCecClose (handle);
-        if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecClose failed"); }
-        HDMICEC_TERM(); UT_FAIL ("HdmiCecAddLogicalAddress failed");
+        HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed");
     }
 
     buf[0] = 0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     //Get logical address
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
 
     /* Invalid input */
     result = HdmiCecTxAsync(handle, NULL, len);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTxAsync failed"); }
 
     result = HdmiCecTxAsync(0, buf, len);
-    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTxAsync failed"); }
 
     /* Invalid input */
     result = HdmiCecTxAsync(handle, buf, INT_MIN);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTxAsync failed"); }
 
 
     buf[0] = ((logicalAddress&0xFF)<<4)|0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
-    /* Positive result */
-    result = HdmiCecTxAsync(handle, buf, len);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
-
-    buf [1] = CEC_DEVICE_VENDOR_ID;
-    /*Back to back send and ensure send is not failed*/
-    result = HdmiCecTxAsync(handle, buf, len);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
-
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
 
     //Calling API after close, should give invalid argument
     result = HdmiCecTxAsync(handle, buf, len);
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecTxAsync failed"); }
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
 
@@ -2011,39 +1871,34 @@ void test_hdmicec_hal_l1_hdmiCecTxAsync_sinkDevice_positive( void )
     /* Positive result */
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
 
     /* Positive result */
     result = HdmiCecSetTxCallback(handle, DriverTransmitCallback, 0);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetTxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetTxCallback failed"); }
 
     //Set logical address for TV
-    logicalAddress = DEFAULT_LOGICAL_ADDRESS;
+    logicalAddress = DEFAULT_LOGICAL_ADDRESS_PANEL;
 
     result = HdmiCecAddLogicalAddress(handle, logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) {
-        /*Cleanup before exiting */
-        result = HdmiCecClose (handle);
-        if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("HdmiCecClose failed"); }
-        UT_FAIL ("HdmiCecAddLogicalAddress failed");
-    }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
 
     buf[0] = 0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     //Get logical address
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
 
 
     buf[0] = ((logicalAddress&0xFF)<<4)|0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     /* Positive result */
     result = HdmiCecTxAsync(handle, buf, len);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTxAsync failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
 
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
@@ -2073,10 +1928,8 @@ void test_hdmicec_hal_l1_hdmiCecTxAsync_sinkDevice_positive( void )
  * |04|Call HdmiCecTxAsync() - call cec message send with invalid argument | handle, buf=NULL, len | HDMI_CEC_IO_INVALID_ARGUMENT| Should Pass |
  * |05|Call HdmiCecTxAsync() - call cec message send with invalid argument | handle=0, buf, len | HDMI_CEC_IO_INVALID_HANDLE| Should Pass |
  * |06|Call HdmiCecTxAsync() - call cec message send with invalid argument | handle, buf, len=INT_MIN | HDMI_CEC_IO_INVALID_ARGUMENT| Should Pass |
- * |07|Call HdmiCecTxAsync() - send the cec message after correct module initialization | handle, buf, len | HDMI_CEC_IO_SUCCESS| Should Pass |
- * |08|Call HdmiCecTxAsync() - back to back send to ensure it is passing | handle, buf, len | HDMI_CEC_IO_SUCCESS| Should Pass |
- * |09|Call HdmiCecClose () - close interface | handle=hdmiHandle | HDMI_CEC_IO_SUCCESS| Should Pass |
- * |10|Call HdmiCecTxAsync()  - call API after module is closed | handle, buf, len | HDMI_CEC_IO_NOT_OPENED| Should Pass |
+ * |08|Call HdmiCecClose () - close interface | handle=hdmiHandle | HDMI_CEC_IO_SUCCESS| Should Pass |
+ * |09|Call HdmiCecTxAsync()  - call API after module is closed | handle, buf, len | HDMI_CEC_IO_NOT_OPENED| Should Pass |
  */
 void test_hdmicec_hal_l1_hdmiCecTxAsync_sourceDevice_negative( void )
 {
@@ -2094,52 +1947,43 @@ void test_hdmicec_hal_l1_hdmiCecTxAsync_sourceDevice_negative( void )
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
     //Calling API before open, should give invalid argument
     result = HdmiCecTxAsync(handle, buf, len); //Code crash here
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecTxAsync failed"); }
 
     /* Positive result */
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
 
     /* Positive result */
     result = HdmiCecSetTxCallback(handle, DriverTransmitCallback, 0);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetTxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetTxCallback failed"); }
 
     buf[0] = 0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     //Get logical address
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
 
     /* Invalid input */
     result = HdmiCecTxAsync(handle, NULL, len);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTxAsync failed"); }
 
     result = HdmiCecTxAsync(0, buf, len);
-    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_INVALID_HANDLE != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTxAsync failed"); }
 
     /* Invalid input */
     result = HdmiCecTxAsync(handle, buf, INT_MIN);
-    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_INVALID_ARGUMENT != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTxAsync failed"); }
 
     buf[0] = ((logicalAddress&0xFF)<<4)|0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
-    /* Positive result */
-    result = HdmiCecTxAsync(handle, buf, len);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
-
-    buf [1] = CEC_DEVICE_VENDOR_ID;
-    /*Back to back send and ensure send is not failed*/
-    result = HdmiCecTxAsync(handle, buf, len);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
-
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
 
     //Calling API after close, should give invalid argument
     result = HdmiCecTxAsync(handle, buf, len);
-    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_NOT_OPENED != result) { UT_FAIL_FATAL ("HdmiCecTxAsync failed"); }
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
 
@@ -2183,34 +2027,102 @@ void test_hdmicec_hal_l1_hdmiCecTxAsync_sourceDevice_positive( void )
     /* Positive result */
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
 
     /* Positive result */
     result = HdmiCecSetTxCallback(handle, DriverTransmitCallback, 0);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetTxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetTxCallback failed"); }
 
     buf[0] = 0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     //Get logical address
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
 
     buf[0] = ((logicalAddress&0xFF)<<4)|0x0F; UT_LOG ("\n hdmicec buf: 0x%x\n", buf[0]);
 
     /* Positive result */
     result = HdmiCecTxAsync(handle, buf, len);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTxAsync failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTxAsync failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
 
+    UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+}
+
+#if 0
+/**
+ * @brief This function will try to ping an unavailable logical address and ensure ACK error happens
+ *
+ * **Test Group ID:** 02@n
+ * **Test Case ID:** 027@n
+ *
+ *
+ * *Pre-Conditions :** @n
+ *  All of the device HDMI cable should be disconnected
+ *
+ **Dependencies :** N/A @n
+ *
+ * **Test Procedure :**@n
+ * |Variation / Step|Description|Test Data|Expected Result|Notes|
+ * |:--:|---------|----------|--------------|-----|
+ * |01|Call `HdmiCecOpen()` - open interface | handle | HDMI_CEC_IO_SUCCESS| Should Pass |
+ * |02|Call `HdmiCecSetRxCallback()` - set RX Call back with valid parameters | handle, DriverTransmitCallback, data address | HDMI_CEC_IO_SUCCESS| Should Pass |
+ * |03|Call `HdmiCecAddLogicalAddress()` - Call add logical address with valid arguments | handle, logicalAddress | HDMI_CEC_IO_SUCCESS| Should Pass |
+ * |04|Call `HdmiCecGetLogicalAddress()` - Call get logical address with valid arguments | handle, &logicalAddress | HDMI_CEC_IO_SUCCESS| Should Pass |
+ * |05|Call `HdmiCecTx()` - Try to ping an unavailable logical address and ensure ACK error | handle, buf, len, &ret | HDMI_CEC_IO_SUCCESS| Should Pass |
+ * |06|Call `HdmiCecSetRxCallback()` - unregister RX Call back | handle, cbfunc=NULL, data address | HDMI_CEC_IO_SUCCESS| Should Pass |
+ * |07|Call `HdmiCecClose ()` - close interface | handle=hdmiHandle | HDMI_CEC_IO_SUCCESS| Should Pass |
+ */
+void test_hdmicec_hal_l1_portDisconnected_sink( void )
+{
+    int result=0;
+    int ret=0;
+    int handle = 0;
+    int logicalAddress = 0;
+    unsigned char buf[] = {0x03};
+    gTestID = 27;
+
+    UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
+    UT_LOG ("\nPlease disconnect All the HDMI ports. Please enter any key to continue"); getchar ();
+
+    /* Positive result */
+    result = HdmiCecOpen (&handle);
+    //if init is failed no need to proceed further
+    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
+
+    /* Positive result */
+    result = HdmiCecSetRxCallback(handle, DriverReceiveCallback, (void*)0xDEADBEEF);
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetRxCallback failed"); }
+
+    //Set logical address for TV.
+    logicalAddress = 0;
+    result = HdmiCecAddLogicalAddress(handle, logicalAddress);
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecAddLogicalAddress failed"); }
+
+    //Get logical address of the device
+    result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
+
+    result = HdmiCecTx(handle, buf, sizeof(buf), &ret);
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SENT_BUT_NOT_ACKD != ret) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
+
+    //Using NULL callback
+    result = HdmiCecSetRxCallback(handle, NULL, 0);
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetRxCallback failed"); }
+
+    /*calling hdmicec_close should pass */
+    result = HdmiCecClose (handle);
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
 
 /**
  * @brief This function will try to ping an unavailable logical address and ensure ACK error happens
- * 
+ *
  * **Test Group ID:** 02@n
  * **Test Case ID:** 032@n
  *
@@ -2247,33 +2159,40 @@ void test_hdmicec_hal_l1_portDisconnected_source( void )
     /* Positive result */
     result = HdmiCecOpen (&handle);
     //if init is failed no need to proceed further
-    UT_ASSERT_EQUAL ( result, HDMI_CEC_IO_SUCCESS );
+    UT_ASSERT_EQUAL_FATAL ( result, HDMI_CEC_IO_SUCCESS );
 
     /* Positive result */
     result = HdmiCecSetRxCallback(handle, DriverReceiveCallback, (void*)0xDEADBEEF);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetRxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetRxCallback failed"); }
 
     //Get logical address of the device
     result = HdmiCecGetLogicalAddress(handle, &logicalAddress);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecGetLogicalAddress failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecGetLogicalAddress failed"); }
 
     result = HdmiCecTx(handle, buf, sizeof(buf), &ret);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
-    if (HDMI_CEC_IO_SENT_BUT_NOT_ACKD != ret) { HDMICEC_TERM(); UT_FAIL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SENT_BUT_NOT_ACKD != ret) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecTx failed"); }
 
     //Using NULL callback
     result = HdmiCecSetRxCallback(handle, NULL, 0);
-    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL ("HdmiCecSetRxCallback failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { HDMICEC_TERM(); UT_FAIL_FATAL ("HdmiCecSetRxCallback failed"); }
 
     /*calling hdmicec_close should pass */
     result = HdmiCecClose (handle);
-    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL ("HdmiCecClose failed"); }
+    if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL_FATAL ("HdmiCecClose failed"); }
     UT_LOG("\n Exit %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 }
+
+#endif
 
 static UT_test_suite_t *pSuiteNegative = NULL;
 static UT_test_suite_t *pSuiteHdmiDisConnected = NULL;
 static UT_test_suite_t *pSuitePositive = NULL;
+static UT_test_suite_t *pSuiteLAUS = NULL;
+static UT_test_suite_t *pSuitePositive_stb = NULL;
+static UT_test_suite_t *pSuiteNegative_stb = NULL;
+static UT_test_suite_t *pSuitePositive_panel = NULL;
+static UT_test_suite_t *pSuiteNegative_panel = NULL;
 
 /**
  * @brief Register the main tests for this module
@@ -2283,56 +2202,59 @@ static UT_test_suite_t *pSuitePositive = NULL;
 int test_hdmicec_hal_l1_register( void )
 {
     /* add a suite to the registry */
-    pSuiteNegative = UT_add_suite("[L1 hdmicec-generic negative]", NULL, NULL);
-    pSuiteHdmiDisConnected = UT_add_suite("[L1 test hdmi disconnected]", NULL, NULL);
-    pSuitePositive = UT_add_suite("[L1 hdmicec-generic positive]", NULL, NULL);
-    if (NULL == pSuiteNegative)
+    pSuitePositive = UT_add_suite("[L1 HDMICEC Positive common TestCase]", NULL, NULL);
+    pSuiteNegative = UT_add_suite("[L1 HDMICEC Negative common TestCase]", NULL, NULL);
+
+    pSuitePositive_stb = UT_add_suite("[L1 HDMICEC Positive STB TestCase]", NULL, NULL);
+    pSuiteNegative_stb = UT_add_suite("[L1 HDMICEC Negative STB TestCase]", NULL, NULL);
+
+    pSuitePositive_panel = UT_add_suite("[L1 HDMICEC Positive PANEL TestCase]", NULL, NULL);
+    pSuiteNegative_panel = UT_add_suite("[L1 HDMICEC Negative PANEL TestCase]", NULL, NULL);
+
+    pSuiteHdmiDisConnected = UT_add_suite("[L1 HDMI Disconnect]", NULL, NULL);
+    pSuiteLAUS = UT_add_suite("[L1 HDMICEC Logical Address TestCase]", NULL, NULL);
+
+    if ((NULL == pSuiteNegative) || (NULL == pSuitePositive) || (NULL == pSuiteHdmiDisConnected) || (NULL == pSuiteLAUS) || (NULL == pSuitePositive_stb) || (NULL == pSuiteNegative_stb) || (NULL == pSuitePositive_panel) || (NULL == pSuiteNegative_panel))
     {
         return -1;
     }
 
     //
-    UT_add_test( pSuiteNegative, "open", test_hdmicec_hal_l1_open_negative);
-    UT_add_test( pSuiteNegative, "close", test_hdmicec_hal_l1_close_negative);
-    UT_add_test( pSuiteNegative, "getPhysicalAddress", test_hdmicec_hal_l1_getPhysicalAddress_negative);
+    UT_add_test( pSuiteNegative, "open_negative", test_hdmicec_hal_l1_open_negative);
+    UT_add_test( pSuiteNegative, "close_negative", test_hdmicec_hal_l1_close_negative);
+    UT_add_test( pSuiteNegative, "getPhysicalAddress_negative", test_hdmicec_hal_l1_getPhysicalAddress_negative);
 
-    UT_add_test( pSuiteNegative, "setRxCallback", test_hdmicec_hal_l1_setRxCallback_negative);
-    UT_add_test( pSuiteNegative, "setTxCallback", test_hdmicec_hal_l1_setTxCallback_negative);
+    UT_add_test( pSuiteNegative, "setRxCallback_negative", test_hdmicec_hal_l1_setRxCallback_negative);
+    UT_add_test( pSuiteNegative, "setTxCallback_negative", test_hdmicec_hal_l1_setTxCallback_negative);
 
-#ifndef __UT_STB__
-    UT_add_test( pSuiteNegative, "addLogicalAddressSink", test_hdmicec_hal_l1_addLogicalAddress_sinkDevice_negative);
-    UT_add_test( pSuiteNegative, "removeLogicalAddressSink", test_hdmicec_hal_l1_removeLogicalAddress_sinkDevice_negative);
-    UT_add_test( pSuiteNegative, "getLogicalAddressSink", test_hdmicec_hal_l1_getLogicalAddress_sinkDevice_negative);
-    UT_add_test( pSuiteNegative, "hdmiCecTxSink", test_hdmicec_hal_l1_hdmiCecTx_sinkDevice_negative);
-    UT_add_test( pSuiteNegative, "hdmiCecTxAsyncSink", test_hdmicec_hal_l1_hdmiCecTxAsync_sinkDevice_negative);
-    UT_add_test( pSuiteNegative, "addLogicalAddressWithAddressInUseSink", test_hdmicec_hal_l1_addLogicalAddressWithAddressInUse_sinkDevice);
-    UT_add_test( pSuiteHdmiDisConnected, "portDisconnectedSink", test_hdmicec_hal_l1_portDisconnected_sink);
-#else
-    UT_add_test( pSuiteNegative, "getLogicalAddressSource", test_hdmicec_hal_l1_getLogicalAddress_sourceDevice_negative);
-    UT_add_test( pSuiteNegative, "hdmiCecTxSource", test_hdmicec_hal_l1_hdmiCecTx_sourceDevice_negative);
-    UT_add_test( pSuiteNegative, "hdmiCecTxAsyncSource", test_hdmicec_hal_l1_hdmiCecTxAsync_sourceDevice_negative);
-    UT_add_test( pSuiteNegative, "open_logical_address_unavailable_source", test_hdmicec_hal_l1_open_logical_address_unavailable_source);
-    UT_add_test( pSuiteHdmiDisConnected, "portDisconnectedSource", test_hdmicec_hal_l1_portDisconnected_source);
-#endif //end of __UT_STB__
+    UT_add_test( pSuiteNegative_panel, "addLogicalAddressSink_negative", test_hdmicec_hal_l1_addLogicalAddress_sinkDevice_negative);
+    UT_add_test( pSuiteNegative_panel, "removeLogicalAddressSink_negative", test_hdmicec_hal_l1_removeLogicalAddress_sinkDevice_negative);
+    UT_add_test( pSuiteNegative_panel, "getLogicalAddressSink_negative", test_hdmicec_hal_l1_getLogicalAddress_sinkDevice_negative);
+    UT_add_test( pSuiteNegative_panel, "hdmiCecTxSink_negative", test_hdmicec_hal_l1_hdmiCecTx_sinkDevice_negative);
+    UT_add_test( pSuiteNegative_panel, "hdmiCecTxAsyncSink_negative", test_hdmicec_hal_l1_hdmiCecTxAsync_sinkDevice_negative);
+    UT_add_test( pSuiteLAUS, "addLogicalAddressWithAddressInUseSink", test_hdmicec_hal_l1_addLogicalAddressWithAddressInUse_sinkDevice);
+    UT_add_test( pSuitePositive_panel, "addLogicalAddressSink_Positive", test_hdmicec_hal_l1_addLogicalAddress_sinkDevice_positive);
+    UT_add_test( pSuitePositive_panel, "removeLogicalAddressSink_Positive", test_hdmicec_hal_l1_removeLogicalAddress_sinkDevice_positive);
+    UT_add_test( pSuitePositive_panel, "getLogicalAddressSink_Positive", test_hdmicec_hal_l1_getLogicalAddress_sinkDevice_positive);
+    UT_add_test( pSuitePositive_panel, "hdmiCecTxSink_Positive", test_hdmicec_hal_l1_hdmiCecTx_sinkDevice_positive);
+    UT_add_test( pSuitePositive_panel, "hdmiCecTxAsyncSink_Positive", test_hdmicec_hal_l1_hdmiCecTxAsync_sinkDevice_positive);
+    //UT_add_test( pSuiteHdmiDisConnected, "portDisconnectedSink", test_hdmicec_hal_l1_portDisconnected_sink);
 
-    UT_add_test( pSuitePositive, "openPositive", test_hdmicec_hal_l1_open_positive);
-    UT_add_test( pSuitePositive, "closePositive", test_hdmicec_hal_l1_close_positive);
-    UT_add_test( pSuitePositive, "getPhysicalAddressPositive", test_hdmicec_hal_l1_getPhysicalAddress_positive);
+    UT_add_test( pSuiteNegative_stb, "getLogicalAddressSource_negative", test_hdmicec_hal_l1_getLogicalAddress_sourceDevice_negative);
+    UT_add_test( pSuiteNegative_stb, "hdmiCecTxSource_negative", test_hdmicec_hal_l1_hdmiCecTx_sourceDevice_negative);
+    UT_add_test( pSuiteNegative_stb, "hdmiCecTxAsyncSource_negative", test_hdmicec_hal_l1_hdmiCecTxAsync_sourceDevice_negative);
+    UT_add_test( pSuiteLAUS, "open_logical_address_unavailable_source", test_hdmicec_hal_l1_open_logical_address_unavailable_source);
+    UT_add_test( pSuitePositive_stb, "getLogicalAddressSource_Positive", test_hdmicec_hal_l1_getLogicalAddress_sourceDevice_positive);
+    UT_add_test( pSuitePositive_stb, "hdmiCecTxSource_Positive", test_hdmicec_hal_l1_hdmiCecTx_sourceDevice_positive);
+    UT_add_test( pSuitePositive_stb, "hdmiCecTxAsyncSource_Positive", test_hdmicec_hal_l1_hdmiCecTxAsync_sourceDevice_positive);
+    //UT_add_test( pSuiteHdmiDisConnected, "portDisconnectedSource", test_hdmicec_hal_l1_portDisconnected_source);
 
-    UT_add_test( pSuitePositive, "setRxCallbackPositive", test_hdmicec_hal_l1_setRxCallback_positive);
-    UT_add_test( pSuitePositive, "setTxCallbackPositive", test_hdmicec_hal_l1_setTxCallback_positive);
+    UT_add_test( pSuitePositive, "open_Positive", test_hdmicec_hal_l1_open_positive);
+    UT_add_test( pSuitePositive, "close_Positive", test_hdmicec_hal_l1_close_positive);
+    UT_add_test( pSuitePositive, "getPhysicalAddress_Positive", test_hdmicec_hal_l1_getPhysicalAddress_positive);
 
-#ifndef __UT_STB__
-    UT_add_test( pSuitePositive, "addLogicalAddressSinkPositive", test_hdmicec_hal_l1_addLogicalAddress_sinkDevice_positive);
-    UT_add_test( pSuitePositive, "removeLogicalAddressSinkPositive", test_hdmicec_hal_l1_removeLogicalAddress_sinkDevice_positive);
-    UT_add_test( pSuitePositive, "getLogicalAddressSinkPositive", test_hdmicec_hal_l1_getLogicalAddress_sinkDevice_positive);
-    UT_add_test( pSuitePositive, "hdmiCecTxSinkPositive", test_hdmicec_hal_l1_hdmiCecTx_sinkDevice_positive);
-    UT_add_test( pSuitePositive, "hdmiCecTxAsyncSinkPositive", test_hdmicec_hal_l1_hdmiCecTxAsync_sinkDevice_positive);
-#else
-    UT_add_test( pSuitePositive, "getLogicalAddressSourcePositive", test_hdmicec_hal_l1_getLogicalAddress_sourceDevice_positive);
-    UT_add_test( pSuitePositive, "hdmiCecTxSourcePositive", test_hdmicec_hal_l1_hdmiCecTx_sourceDevice_positive);
-    UT_add_test( pSuitePositive, "hdmiCecTxAsyncSourcePositive", test_hdmicec_hal_l1_hdmiCecTxAsync_sourceDevice_positive);
-#endif //end of __UT_STB__
+    UT_add_test( pSuitePositive, "setRxCallback_Positive", test_hdmicec_hal_l1_setRxCallback_positive);
+    UT_add_test( pSuitePositive, "setTxCallback_Positive", test_hdmicec_hal_l1_setTxCallback_positive);
 
     return 0;
 }

--- a/src/test_l2_hdmi_cec_driver.c
+++ b/src/test_l2_hdmi_cec_driver.c
@@ -51,7 +51,7 @@
 */
 void test_l2_hdmi_cec_driver (void)
 {
-	UT_FAIL(This function needs to be implemented!); 
+	UT_FAIL("This function needs to be implemented!");
 }
 
 static UT_test_suite_t * pSuite = NULL;


### PR DESCRIPTION
In order to support V2 of the ut-core, the following changes need to take place to the current testing code

Upgrade trigger scripts to support V2 of the testing suites
V2 introduces fall through for the UT_ASSERT macros, so verify that all the tests are correctly operating with the fall through model.