### PR TITLE
Issue fix L1 and L2

### DIFF
--- a/docs/pages/hdmi-cec-sink_L2_Low-Level_TestSpec.md
+++ b/docs/pages/hdmi-cec-sink_L2_Low-Level_TestSpec.md
@@ -274,7 +274,7 @@ If the user chooses to run the test in interactive mode, then the test case has 
 | Variation / Steps | Description | Test Data | Expected Result | Notes|
 | -- | --------- | ---------- | -------------- | ----- |
 | 01 | Open HDMI CEC HAL using HdmiCecOpen | handle = valid buffer | HDMI_CEC_IO_SUCCESS | Should be successful |
-| 02 | Add logical address using HdmiCecAddLogicalAddress | handle = valid handle, logicalAddresses = 0x4 | HDMI_CEC_IO_SUCCESS | Should be successful |
+| 02 | Add logical address using HdmiCecAddLogicalAddress | handle = valid handle, logicalAddresses = 0x0 | HDMI_CEC_IO_SUCCESS | Should be successful |
 | 03 | Transmit CEC command using HdmiCecTx for a non existing device | handle = valid handle, buf = {0x47, 0x9F}, len = sizeof(buf), result = valid buffer | HDMI_CEC_IO_SUCCESS, result = HDMI_CEC_IO_SENT_BUT_NOT_ACKD | Should be successful |
 | 04 | Remove logical address using HdmiCecRemoveLogicalAddress | handle = valid handle, logicalAddresses = 0x4 | HDMI_CEC_IO_SUCCESS | Should be successful |
 | 05 | Close HDMI CEC HAL using HdmiCecClose | handle = valid handle | HDMI_CEC_IO_SUCCESS | Should be successful |

--- a/src/test_l1_hdmi_cec_driver.c
+++ b/src/test_l1_hdmi_cec_driver.c
@@ -640,6 +640,7 @@ void test_hdmicec_hal_l1_addLogicalAddress_positive( void )
  * |02|Call HdmiCecOpen() - open interface | handle | HDMI_CEC_IO_SUCCESS| Should Pass |
  * |03|Call HdmiCecRemoveLogicalAddress() - call with invalid handle | handle=0, logicalAddress | HDMI_CEC_IO_INVALID_HANDLE| Should Pass |
  * |04|Call HdmiCecRemoveLogicalAddress() - call with invalid logical address | handle, logicalAddress=0x10 | HDMI_CEC_IO_INVALID_ARGUMENT| Should Pass |
+ * |04|Call HdmiCecRemoveLogicalAddress() - call with invalid logical address | handle, logicalAddress=-1  | HDMI_CEC_IO_INVALID_ARGUMENT| Should Pass |
  * |05|Call HdmiCecRemoveLogicalAddress() - Try to remove with out adding the logical address| handle, logicalAddress | HDMI_CEC_IO_NOT_ADDED| Should Pass |
  * |06|Call HdmiCecAddLogicalAddress() - call with valid arguments | handle, logicalAddress | HDMI_CEC_IO_SUCCESS| Should Pass |
  * |07|Call HdmiCecRemoveLogicalAddress() - remove allocated logical address.  | handle, logicalAddress | HDMI_CEC_IO_SUCCESS| Should Pass|

--- a/src/test_l1_hdmi_cec_driver.c
+++ b/src/test_l1_hdmi_cec_driver.c
@@ -1404,7 +1404,7 @@ void test_hdmicec_hal_l1_hdmiCecTx_sinkDevice_positive( void )
 
     int len = 2;
     //Get CEC Version. return expected is opcode: CEC Version :43 9E 05
-    //Sender as 3 and broadcast
+    //Sender as 3 and to CEC address 8
     unsigned char buf[] = {0x38, CEC_GET_CEC_VERSION};
 
 

--- a/src/test_l1_hdmi_cec_driver.c
+++ b/src/test_l1_hdmi_cec_driver.c
@@ -640,10 +640,10 @@ void test_hdmicec_hal_l1_addLogicalAddress_positive( void )
  * |02|Call HdmiCecOpen() - open interface | handle | HDMI_CEC_IO_SUCCESS| Should Pass |
  * |03|Call HdmiCecRemoveLogicalAddress() - call with invalid handle | handle=0, logicalAddress | HDMI_CEC_IO_INVALID_HANDLE| Should Pass |
  * |04|Call HdmiCecRemoveLogicalAddress() - call with invalid logical address | handle, logicalAddress=0x10 | HDMI_CEC_IO_INVALID_ARGUMENT| Should Pass |
- * |05|Call HdmiCecRemoveLogicalAddress() - Try to remove with out adding the logical address| handle, logicalAddress | HDMI_CEC_IO_ALREADY_REMOVED| Should Pass |
+ * |05|Call HdmiCecRemoveLogicalAddress() - Try to remove with out adding the logical address| handle, logicalAddress | HDMI_CEC_IO_NOT_ADDED| Should Pass |
  * |06|Call HdmiCecAddLogicalAddress() - call with valid arguments | handle, logicalAddress | HDMI_CEC_IO_SUCCESS| Should Pass |
  * |07|Call HdmiCecRemoveLogicalAddress() - remove allocated logical address.  | handle, logicalAddress | HDMI_CEC_IO_SUCCESS| Should Pass|
- * |08|Call HdmiCecRemoveLogicalAddress() - remove same logical address again. | handle, logicalAddress | HDMI_CEC_IO_ALREADY_REMOVED| Should Pass |
+ * |08|Call HdmiCecRemoveLogicalAddress() - remove same logical address again. | handle, logicalAddress | HDMI_CEC_IO_NOT_ADDED| Should Pass |
  * |09|Call HdmiCecClose() - close interface | handle=hdmiHandle | HDMI_CEC_IO_SUCCESS| Should Pass |
  * |10|Call HdmiCecRemoveLogicalAddress() - call after module is closed | handle, logicalAddress | HDMI_CEC_IO_NOT_OPENED| Should Pass |
  */
@@ -723,7 +723,7 @@ void test_hdmicec_hal_l1_removeLogicalAddress_negative( void )
         }
 
         result = HdmiCecRemoveLogicalAddress(handle, logicalAddress);
-        CHECK_FOR_EXTENDED_ERROR_CODE(result, HDMI_CEC_IO_ALREADY_REMOVED, HDMI_CEC_IO_SUCCESS);
+        CHECK_FOR_EXTENDED_ERROR_CODE(result, HDMI_CEC_IO_NOT_ADDED, HDMI_CEC_IO_SUCCESS);
 
         result = HdmiCecClose(handle);
         if (HDMI_CEC_IO_SUCCESS != result)

--- a/src/test_l1_hdmi_cec_driver.c
+++ b/src/test_l1_hdmi_cec_driver.c
@@ -1935,7 +1935,7 @@ int test_hdmidec_hal_l1_register(void)
 {
     char typeString[UT_KVP_MAX_ELEMENT_SIZE];
 
-    extendedEnumsSupported = ut_kvp_getBoolField( ut_kvp_profile_getInstance(), "hdmicec/features/extendedEnumsSupported" );
+    extendedEnumsSupported = UT_KVP_PROFILE_GET_BOOL("hdmicec/features/extendedEnumsSupported");
 
     UT_KVP_PROFILE_GET_STRING("hdmicec/type",typeString);
     if(strncmp(typeString,"source",UT_KVP_MAX_ELEMENT_SIZE) == 0){

--- a/src/test_l1_hdmi_cec_driver.c
+++ b/src/test_l1_hdmi_cec_driver.c
@@ -1435,7 +1435,7 @@ void test_hdmicec_hal_l1_hdmiCecTx_sinkDevice_positive( void )
     /* Positive result */
     result = HdmiCecTx(handle, buf, len, &ret);
     if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecTx failed"); }
-    if (HDMI_CEC_IO_SENT_AND_ACKD != ret) { UT_FAIL("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SENT_BUT_NOT_ACKD  != ret) { UT_FAIL("HdmiCecTx failed"); }
 
     /* Remove Logical address*/
     result = HdmiCecRemoveLogicalAddress( handle, logicalAddress );

--- a/src/test_l1_hdmi_cec_driver.c
+++ b/src/test_l1_hdmi_cec_driver.c
@@ -1405,7 +1405,7 @@ void test_hdmicec_hal_l1_hdmiCecTx_sinkDevice_positive( void )
     int len = 2;
     //Get CEC Version. return expected is opcode: CEC Version :43 9E 05
     //Sender as 3 and broadcast
-    unsigned char buf[] = {0x3F, CEC_GET_CEC_VERSION};
+    unsigned char buf[] = {0x38, CEC_GET_CEC_VERSION};
 
 
     UT_LOG("\n In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
@@ -1435,7 +1435,7 @@ void test_hdmicec_hal_l1_hdmiCecTx_sinkDevice_positive( void )
     /* Positive result */
     result = HdmiCecTx(handle, buf, len, &ret);
     if (HDMI_CEC_IO_SUCCESS != result) { UT_FAIL("HdmiCecTx failed"); }
-    if (HDMI_CEC_IO_SENT_BUT_NOT_ACKD != ret) { UT_FAIL("HdmiCecTx failed"); }
+    if (HDMI_CEC_IO_SENT_AND_ACKD != ret) { UT_FAIL("HdmiCecTx failed"); }
 
     /* Remove Logical address*/
     result = HdmiCecRemoveLogicalAddress( handle, logicalAddress );
@@ -1934,6 +1934,8 @@ static UT_test_suite_t *pSuite = NULL;
 int test_hdmidec_hal_l1_register(void)
 {
     char typeString[UT_KVP_MAX_ELEMENT_SIZE];
+
+    extendedEnumsSupported = ut_kvp_getBoolField( ut_kvp_profile_getInstance(), "hdmicec/features/extendedEnumsSupported" );
 
     UT_KVP_PROFILE_GET_STRING("hdmicec/type",typeString);
     if(strncmp(typeString,"source",UT_KVP_MAX_ELEMENT_SIZE) == 0){

--- a/src/test_l2_hdmi_cec_sink_driver.c
+++ b/src/test_l2_hdmi_cec_sink_driver.c
@@ -413,7 +413,7 @@ void test_l2_hdmi_cec_sink_hal_TransmitCECCommand(void)
     UT_LOG_INFO("In %s [%02d%03d]\n", __FUNCTION__, gTestGroup, gTestID);
 
     int handle;
-    int logicalAddresses = 0x4; // Example logical address
+    int logicalAddresses = 0x0; // Example logical address
     unsigned char buf[] = {0x47, 0x9F}; // Example CEC message
     int len = sizeof(buf);
     int result;


### PR DESCRIPTION
* Update Logic in HdmiCecRmoveLogicAddress negative test
* Update logic address in the test test_l2_hdmi_cec_sink_hal_TransmitCECCommand - Broadcast ACK is always 1.. if zero considered some one had rejected it.  Check section 61.2 of HDMI CEC 1.4 spec.

Closes : #58 