### PR TITLE
gh #85 failed to run hdmi cec L3 test suite as parameter is missing for hdmiCECClass

### DIFF
--- a/host/tests/hdmiCEC_L1L2_Tests/hdmiCEC_L1_L2_sink_testSetup.yml
+++ b/host/tests/hdmiCEC_L1L2_Tests/hdmiCEC_L1_L2_sink_testSetup.yml
@@ -16,6 +16,18 @@ hdmicec:
     #######################################
     - name: "L1 HDMI CEC SINK TestCase"
       test_cases:
+        - getLogicalAddress_Positive
+    - name: "L1 HDMI CEC SINK TestCase"
+      test_cases:
+        - getLogicalAddress_negative
+    - name: "L1 HDMI CEC SINK TestCase"
+      test_cases:
+        - Tx_Positive
+    - name: "L1 HDMI CEC SINK TestCase"
+      test_cases:
+        - Tx_negative
+    - name: "L1 HDMI CEC SINK TestCase"
+      test_cases:
         - open_Positive
     - name: "L1 HDMI CEC SINK TestCase"
       test_cases:
@@ -50,18 +62,7 @@ hdmicec:
     - name: "L1 HDMI CEC SINK TestCase"
       test_cases:
         - removeLogicalAddress_negative
-    - name: "L1 HDMI CEC SINK TestCase"
-      test_cases:
-        - getLogicalAddress_Positive
-    - name: "L1 HDMI CEC SINK TestCase"
-      test_cases:
-        - getLogicalAddress_negative
-    - name: "L1 HDMI CEC SINK TestCase"
-      test_cases:
-        - Tx_Positive
-    - name: "L1 HDMI CEC SINK TestCase"
-      test_cases:
-        - Tx_negative
+
     #######################################
     # Entries to run individual test cases
     #######################################

--- a/host/tests/hdmiCEC_L1L2_Tests/hdmiCEC_L1_L2_source_testSetup.yml
+++ b/host/tests/hdmiCEC_L1L2_Tests/hdmiCEC_L1_L2_source_testSetup.yml
@@ -16,6 +16,18 @@ hdmicec:
     #######################################
     - name: "L1 HDMI CEC Source TestCase"
       test_cases:
+        - getLogicalAddress_Positive
+    - name: "L1 HDMI CEC Source TestCase"
+      test_cases:
+        - getLogicalAddress_negative
+    - name: "L1 HDMI CEC Source TestCase"
+      test_cases:
+        - Tx_Positive
+    - name: "L1 HDMI CEC Source TestCase"
+      test_cases:
+        - Tx_negative
+    - name: "L1 HDMI CEC Source TestCase"
+      test_cases:
         - open_Positive
     - name: "L1 HDMI CEC Source TestCase"
       test_cases:
@@ -50,18 +62,7 @@ hdmicec:
     - name: "L1 HDMI CEC Source TestCase"
       test_cases:
        - removeLogicalAddress_negative
-    - name: "L1 HDMI CEC Source TestCase"
-      test_cases:
-        - getLogicalAddress_Positive
-    - name: "L1 HDMI CEC Source TestCase"
-      test_cases:
-        - getLogicalAddress_negative
-    - name: "L1 HDMI CEC Source TestCase"
-      test_cases:
-        - Tx_Positive
-    - name: "L1 HDMI CEC Source TestCase"
-      test_cases:
-        - Tx_negative
+
     #######################################
     # Entries to run individual test cases
     #######################################

--- a/host/tests/hdmiCEC_L3_Tests/hdmiCECHelperClass.py
+++ b/host/tests/hdmiCEC_L3_Tests/hdmiCECHelperClass.py
@@ -55,6 +55,7 @@ class hdmiCECHelperClass(utHelperClass):
         self.testName  = ""
         self.moduleName = "hdmicec"
         self.rackDevice = "dut"
+        self.testsuite  = "L3 HDMICEC Functions"
 
         # Initialize the base helper class
         super().__init__(testName, qcId, log)
@@ -90,7 +91,7 @@ class hdmiCECHelperClass(utHelperClass):
         """
 
         # Create the hdmiCEC class
-        self.testhdmiCEC = hdmiCECClass(self.moduleConfigProfileFile, self.hal_session, self.targetWorkspace)
+        self.testhdmiCEC = hdmiCECClass(self.moduleConfigProfileFile, self.hal_session, self.testsuite, self.targetWorkspace)
         self.deviceType  = self.testhdmiCEC.getDeviceType()
 
         return True


### PR DESCRIPTION
Hdmi CEC L3 test suite failed to run as parameter is missing in hdmiCECClass.
Added the parameter in hdmiCECClass of /host/tests/hdmiCEC_L3_Tests/hdmiCECHelperClass.py.
Also rearranged L1 test cases list in /host/tests/hdmiCEC_L1L2_Tests/hdmiCEC_L1_L2_sink_testSetup.yml & /host/tests/hdmiCEC_L1L2_Tests/hdmiCEC_L1_L2_source_testSetup.yml to match with the binary list.