### PR TITLE
gh #117 Test cases failed to run with python env as not finding Test case name

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -28,7 +28,7 @@ NC="\e[39m"
 # When the major version changes in the ut-core, what that signals is that the testings will have to be upgraded to support that version
 # Therefore in that case it warns you but doesnt' chnage to that version, which could cause your tests to break.
 # Change this to upgrade your UT-Core Major versions. Non ABI Changes 1.x.x are supported, between major revisions
-UT_PROJECT_MAJOR_VERSION="4."
+UT_PROJECT_MAJOR_VERSION="5."
 
 # Clone the Unit Test Requirements
 TEST_REPO=git@github.com:rdkcentral/ut-core.git


### PR DESCRIPTION
Any of the L1/L2 testcase is not executed through python.

**Solution:**
Ut_core version need to be changed to 5 in build.sh