### PR TITLE
Convert DS_ASSERT to UT_ASSERT instead of assert function

### DIFF
--- a/src/test_l3_hdmi_cec_driver.c
+++ b/src/test_l3_hdmi_cec_driver.c
@@ -463,14 +463,13 @@ void test_l3_hdmi_cec_hal_Init(void)
     UT_LOG_INFO("Result HdmiCecSetRxCallback(IN:handle:[0x%0X], IN:cbfunc:[0x%0X]) HDMI_CEC_STATUS:[%s]",gHandle,onRxDataReceived, UT_Control_GetMapString(cecError_mapTable,status));
     UT_ASSERT_EQUAL(status, HDMI_CEC_IO_SUCCESS);
 
-    gPhysicalAddressBytes = (uint8_t*)&gPhysicalAddress;
-
     UT_LOG_INFO("Calling HdmiCecGetPhysicalAddress(IN:handle:[0x%0X], OUT:physicalAddress:[])", gHandle);
     status = HdmiCecGetPhysicalAddress(gHandle, &gPhysicalAddress);
     UT_ASSERT_EQUAL(status, HDMI_CEC_IO_SUCCESS);
 
     if (status == HDMI_CEC_IO_SUCCESS)
     {
+        gPhysicalAddressBytes = (uint8_t*)&gPhysicalAddress;
         UT_LOG_INFO("Result HdmiCecGetPhysicalAddress(IN:handle:[0x%0X], OUT:physicalAddress:[%01x.%01x.%01x.%01x]) HDMI_CEC_STATUS:[%s]",
             gHandle, gPhysicalAddressBytes[3], gPhysicalAddressBytes[2], gPhysicalAddressBytes[1], gPhysicalAddressBytes[0],
             UT_Control_GetMapString(cecError_mapTable, status));
@@ -555,7 +554,15 @@ void test_l3_hdmi_cec_hal_AddLogicalAddress(void)
 
         UT_ASSERT_EQUAL(logicalAddress, getLogicalAddress);
 
-        gLogicalAddress = getLogicalAddress;
+        if (logicalAddress == getLogicalAddress)
+        {
+            gLogicalAddress = getLogicalAddress;
+        }
+        else
+        {
+            UT_LOG_ERROR("Logical address mismatch. Expected: %x, Got: %x",
+                        logicalAddress, getLogicalAddress);
+        }
     }
     else
     {
@@ -599,7 +606,14 @@ void test_l3_hdmi_cec_hal_GetLogicalAddress(void)
 
         UT_ASSERT_TRUE(logicalAddress >= 0 && logicalAddress <= 15);
 
-        gLogicalAddress = logicalAddress;
+        if (logicalAddress >= 0 && logicalAddress <= 15)
+        {
+            gLogicalAddress = logicalAddress;
+        }
+        else
+        {
+            UT_LOG_ERROR("Logical address out of valid range: %x", logicalAddress);
+        }
     }
     else
     {

--- a/src/test_l3_hdmi_cec_driver.c
+++ b/src/test_l3_hdmi_cec_driver.c
@@ -471,8 +471,6 @@ void test_l3_hdmi_cec_hal_Init(void)
 
     if (status == HDMI_CEC_IO_SUCCESS)
     {
-        gPhysicalAddressBytes = (uint8_t*)&gPhysicalAddress;
-
         UT_LOG_INFO("Result HdmiCecGetPhysicalAddress(IN:handle:[0x%0X], OUT:physicalAddress:[%01x.%01x.%01x.%01x]) HDMI_CEC_STATUS:[%s]",
             gHandle, gPhysicalAddressBytes[3], gPhysicalAddressBytes[2], gPhysicalAddressBytes[1], gPhysicalAddressBytes[0],
             UT_Control_GetMapString(cecError_mapTable, status));
@@ -592,20 +590,22 @@ void test_l3_hdmi_cec_hal_GetLogicalAddress(void)
 
     UT_LOG_INFO("Calling HdmiCecGetLogicalAddress(IN:handle:[0x%0X], OUT:logicalAddress:[])", gHandle);
     status = HdmiCecGetLogicalAddress(gHandle, &logicalAddress);
-    UT_LOG_INFO("Result HdmiCecGetLogicalAddress(IN:handle:[0x%0X], OUT:logicalAddress:[%x]) HDMI_CEC_STATUS:[%s])", gHandle, logicalAddress, UT_Control_GetMapString(cecError_mapTable,status));
     UT_ASSERT_EQUAL(status, HDMI_CEC_IO_SUCCESS);
-
+    
     if (status == HDMI_CEC_IO_SUCCESS)
     {
+        UT_LOG_INFO("Result HdmiCecGetLogicalAddress(IN:handle:[0x%0X], OUT:logicalAddress:[%x]) HDMI_CEC_STATUS:[%s])",
+                    gHandle, logicalAddress, UT_Control_GetMapString(cecError_mapTable, status));
+
         UT_ASSERT_TRUE(logicalAddress >= 0 && logicalAddress <= 15);
+
         gLogicalAddress = logicalAddress;
     }
     else
     {
-        UT_LOG_ERROR("HdmiCecGetLogicalAddress failed. HDMI_CEC_STATUS:[%d] [%s]",
-            status, UT_Control_GetMapString(cecError_mapTable, status));
+        UT_LOG_ERROR("HdmiCecGetLogicalAddress failed.");
     }
-
+    
     UT_LOG_INFO("Out %s\n", __FUNCTION__);
 }
 
@@ -639,9 +639,10 @@ void test_l3_hdmi_cec_hal_TransmitHdmiCecCommand(void) {
     int32_t expectedDataLength;
 
     UT_ASSERT_NOT_EQUAL(sourceLogicalAddress, -1);
+
     if (sourceLogicalAddress == -1)
     {
-        UT_LOG_ERROR("Invalid source logical address. Add a logical address before transmitting a CEC command.");
+        UT_LOG_ERROR("Invalid source logical address.");
         return;
     }
 
@@ -690,6 +691,11 @@ void test_l3_hdmi_cec_hal_TransmitHdmiCecCommand(void) {
     UT_LOG_INFO("Result HdmiCecTx(IN:handle:[0x%0X], IN:buf:[%p], IN:len:[%d], OUT:result:[%s]) HDMI_CEC_STATUS:[%s]", gHandle, buf, len, UT_Control_GetMapString(cecError_mapTable, result)? UT_Control_GetMapString(cecError_mapTable, result):"HDMI_CEC_IO_SENT_FAILED", UT_Control_GetMapString(cecError_mapTable,status));
     UT_ASSERT_TRUE(status == HDMI_CEC_IO_SUCCESS || status == HDMI_CEC_IO_SENT_AND_ACKD || status == HDMI_CEC_IO_SENT_BUT_NOT_ACKD );
 
+    if (!(status == HDMI_CEC_IO_SUCCESS || status == HDMI_CEC_IO_SENT_AND_ACKD || status == HDMI_CEC_IO_SENT_BUT_NOT_ACKD))
+    {
+        UT_LOG_ERROR("HdmiCecTx failed.");
+    }
+
     UT_LOG_INFO("Out %s\n", __FUNCTION__);
 }
 
@@ -721,7 +727,6 @@ void test_l3_hdmi_cec_hal_GetPhysicalAddress(void)
 
     if (status == HDMI_CEC_IO_SUCCESS)
     {
-        gPhysicalAddressBytes = (uint8_t*)&gPhysicalAddress;
         UT_LOG_INFO("Result HdmiCecGetPhysicalAddress(IN:handle:[0x%0X], OUT:physicalAddress:[%01x.%01x.%01x.%01x]) HDMI_CEC_STATUS:[%s]",
                     gHandle, gPhysicalAddressBytes[3], gPhysicalAddressBytes[2], gPhysicalAddressBytes[1], gPhysicalAddressBytes[0],
                     UT_Control_GetMapString(cecError_mapTable, status));
@@ -784,7 +789,7 @@ void test_l3_hdmi_cec_hal_RemoveLogicalAddress(void)
     }
     else
     {
-        UT_LOG_ERROR("HdmiCecRemoveLogicalAddress failed. State not updated.");
+        UT_LOG_ERROR("HdmiCecRemoveLogicalAddress failed.");
     }
 
     UT_LOG_INFO("Out %s\n", __FUNCTION__);

--- a/src/test_l3_hdmi_cec_driver.c
+++ b/src/test_l3_hdmi_cec_driver.c
@@ -455,7 +455,7 @@ void test_l3_hdmi_cec_hal_Init(void)
     status = HdmiCecOpen(&gHandle);
     UT_LOG_INFO("Result HdmiCecOpen(OUT:handle:[0x%0X]) HDMI_CEC_STATUS:[%s]",gHandle, UT_Control_GetMapString(cecError_mapTable,status));
     UT_ASSERT_EQUAL_FATAL(status, HDMI_CEC_IO_SUCCESS);
-    UT_ASSERT_NOT_EQUAL(gHandle, 0);
+    UT_ASSERT_NOT_EQUAL_FATAL(gHandle, 0);
 
     // Step 2: Register the call back
     UT_LOG_INFO("Calling HdmiCecSetRxCallback(IN:handle:[0x%0X], IN:cbfunc:[0x%0X])",gHandle, onRxDataReceived);
@@ -594,9 +594,18 @@ void test_l3_hdmi_cec_hal_GetLogicalAddress(void)
     status = HdmiCecGetLogicalAddress(gHandle, &logicalAddress);
     UT_LOG_INFO("Result HdmiCecGetLogicalAddress(IN:handle:[0x%0X], OUT:logicalAddress:[%x]) HDMI_CEC_STATUS:[%s])", gHandle, logicalAddress, UT_Control_GetMapString(cecError_mapTable,status));
     UT_ASSERT_EQUAL(status, HDMI_CEC_IO_SUCCESS);
-    UT_ASSERT_TRUE(logicalAddress >= 0 && logicalAddress <= 15);
 
-    gLogicalAddress = logicalAddress;
+    if (status == HDMI_CEC_IO_SUCCESS)
+    {
+        UT_ASSERT_TRUE(logicalAddress >= 0 && logicalAddress <= 15);
+        gLogicalAddress = logicalAddress;
+    }
+    else
+    {
+        UT_LOG_ERROR("HdmiCecGetLogicalAddress failed. HDMI_CEC_STATUS:[%d] [%s]",
+            status, UT_Control_GetMapString(cecError_mapTable, status));
+    }
+
     UT_LOG_INFO("Out %s\n", __FUNCTION__);
 }
 
@@ -630,6 +639,11 @@ void test_l3_hdmi_cec_hal_TransmitHdmiCecCommand(void) {
     int32_t expectedDataLength;
 
     UT_ASSERT_NOT_EQUAL(sourceLogicalAddress, -1);
+    if (sourceLogicalAddress == -1)
+    {
+        UT_LOG_ERROR("Invalid source logical address. Add a logical address before transmitting a CEC command.");
+        return;
+    }
 
     // Reading inputs from the user or test framework
     UT_LOG_MENU_INFO("Enter a valid Destination Logical Address: ");
@@ -707,7 +721,7 @@ void test_l3_hdmi_cec_hal_GetPhysicalAddress(void)
 
     if (status == HDMI_CEC_IO_SUCCESS)
     {
-
+        gPhysicalAddressBytes = (uint8_t*)&gPhysicalAddress;
         UT_LOG_INFO("Result HdmiCecGetPhysicalAddress(IN:handle:[0x%0X], OUT:physicalAddress:[%01x.%01x.%01x.%01x]) HDMI_CEC_STATUS:[%s]",
                     gHandle, gPhysicalAddressBytes[3], gPhysicalAddressBytes[2], gPhysicalAddressBytes[1], gPhysicalAddressBytes[0],
                     UT_Control_GetMapString(cecError_mapTable, status));
@@ -800,7 +814,10 @@ void test_l3_hdmi_cec_hal_Close(void)
     status = HdmiCecClose(gHandle);
     UT_LOG_INFO("Result HdmiCecClose(IN:handle:[0x%0X]) HDMI_CEC_STATUS:[%s]", gHandle, UT_Control_GetMapString(cecError_mapTable,status));
     UT_ASSERT_EQUAL(status, HDMI_CEC_IO_SUCCESS);
-    gHandle = 0;
+    if (status == HDMI_CEC_IO_SUCCESS)
+    {
+        gHandle = 0;
+    }
 
     UT_LOG_INFO("Out %s\n", __FUNCTION__);
 }

--- a/src/test_l3_hdmi_cec_driver.c
+++ b/src/test_l3_hdmi_cec_driver.c
@@ -559,7 +559,7 @@ void test_l3_hdmi_cec_hal_AddLogicalAddress(void)
     }
     else
     {
-        UT_LOG_ERROR("HdmiCecGetLogicalAddress failed. Cannot validate logical address.");
+        UT_LOG_ERROR("HdmiCecGetLogicalAddress failed.");
     }
 
     UT_LOG_INFO("Out %s\n", __FUNCTION__);

--- a/src/test_l3_hdmi_cec_driver.c
+++ b/src/test_l3_hdmi_cec_driver.c
@@ -454,7 +454,7 @@ void test_l3_hdmi_cec_hal_Init(void)
     UT_LOG_INFO("Calling HdmiCecOpen(OUT:handle:[])");
     status = HdmiCecOpen(&gHandle);
     UT_LOG_INFO("Result HdmiCecOpen(OUT:handle:[0x%0X]) HDMI_CEC_STATUS:[%s]",gHandle, UT_Control_GetMapString(cecError_mapTable,status));
-    UT_ASSERT_EQUAL(status, HDMI_CEC_IO_SUCCESS);
+    UT_ASSERT_EQUAL_FATAL(status, HDMI_CEC_IO_SUCCESS);
     UT_ASSERT_NOT_EQUAL(gHandle, 0);
 
     // Step 2: Register the call back
@@ -467,10 +467,20 @@ void test_l3_hdmi_cec_hal_Init(void)
 
     UT_LOG_INFO("Calling HdmiCecGetPhysicalAddress(IN:handle:[0x%0X], OUT:physicalAddress:[])", gHandle);
     status = HdmiCecGetPhysicalAddress(gHandle, &gPhysicalAddress);
-    UT_LOG_INFO("Result HdmiCecGetPhysicalAddress(IN:handle:[0x%0X], OUT:physicalAddress:[%01x.%01x.%01x.%01x]) HDMI_CEC_STATUS:[%s]", gHandle,
-                                                  gPhysicalAddressBytes[3], gPhysicalAddressBytes[2], gPhysicalAddressBytes[1], gPhysicalAddressBytes[0],
-                                                  UT_Control_GetMapString(cecError_mapTable,status));
     UT_ASSERT_EQUAL(status, HDMI_CEC_IO_SUCCESS);
+
+    if (status == HDMI_CEC_IO_SUCCESS)
+    {
+        gPhysicalAddressBytes = (uint8_t*)&gPhysicalAddress;
+
+        UT_LOG_INFO("Result HdmiCecGetPhysicalAddress(IN:handle:[0x%0X], OUT:physicalAddress:[%01x.%01x.%01x.%01x]) HDMI_CEC_STATUS:[%s]",
+            gHandle, gPhysicalAddressBytes[3], gPhysicalAddressBytes[2], gPhysicalAddressBytes[1], gPhysicalAddressBytes[0],
+            UT_Control_GetMapString(cecError_mapTable, status));
+    }
+    else
+    {
+        UT_LOG_ERROR("HdmiCecGetPhysicalAddress failed.");
+    }
 
     if (gDeviceType == SOURCE)
     {
@@ -529,14 +539,30 @@ void test_l3_hdmi_cec_hal_AddLogicalAddress(void)
     status = HdmiCecAddLogicalAddress(gHandle, logicalAddress);
     UT_LOG_INFO("Result HdmiCecAddLogicalAddress (IN:handle:[0x%0X], IN:logicalAddress:[%x]) HDMI_CEC_STATUS[%s]",gHandle,logicalAddress,UT_Control_GetMapString(cecError_mapTable,status));
     UT_ASSERT_EQUAL(status, HDMI_CEC_IO_SUCCESS);
+    if (status != HDMI_CEC_IO_SUCCESS)
+    {
+        UT_LOG_ERROR("HdmiCecAddLogicalAddress failed.");
+        return;
+    }
 
     UT_LOG_INFO("Calling HdmiCecGetLogicalAddress(IN:handle:[0x%0X], OUT:logicalAddress:[])", gHandle);
     status = HdmiCecGetLogicalAddress(gHandle, &getLogicalAddress);
-    UT_LOG_INFO("Result HdmiCecGetLogicalAddress(IN:handle:[0x%0X], OUT:logicalAddress:[%x]) HDMI_CEC_STATUS:[%s])", gHandle, getLogicalAddress, UT_Control_GetMapString(cecError_mapTable,status));
     UT_ASSERT_EQUAL(status, HDMI_CEC_IO_SUCCESS);
-    UT_ASSERT_EQUAL(logicalAddress, getLogicalAddress);
 
-    gLogicalAddress = getLogicalAddress;
+    if (status == HDMI_CEC_IO_SUCCESS)
+    {
+        UT_LOG_INFO("Result HdmiCecGetLogicalAddress(IN:handle:[0x%0X], OUT:logicalAddress:[%x]) HDMI_CEC_STATUS:[%s])",
+                    gHandle, getLogicalAddress,
+                    UT_Control_GetMapString(cecError_mapTable, status));
+
+        UT_ASSERT_EQUAL(logicalAddress, getLogicalAddress);
+
+        gLogicalAddress = getLogicalAddress;
+    }
+    else
+    {
+        UT_LOG_ERROR("HdmiCecGetLogicalAddress failed. Cannot validate logical address.");
+    }
 
     UT_LOG_INFO("Out %s\n", __FUNCTION__);
 }
@@ -677,10 +703,19 @@ void test_l3_hdmi_cec_hal_GetPhysicalAddress(void)
 
     UT_LOG_INFO("Calling HdmiCecGetPhysicalAddress(IN:handle:[0x%0X], OUT:physicalAddress:[])", gHandle);
     status = HdmiCecGetPhysicalAddress(gHandle, &gPhysicalAddress);
-    UT_LOG_INFO("Result HdmiCecGetPhysicalAddress(IN:handle:[0x%0X], OUT:physicalAddress:[%01x.%01x.%01x.%01x]) HDMI_CEC_STATUS:[%s]", gHandle,
-                                                  gPhysicalAddressBytes[3], gPhysicalAddressBytes[2], gPhysicalAddressBytes[1], gPhysicalAddressBytes[0],
-                                                  UT_Control_GetMapString(cecError_mapTable,status));
     UT_ASSERT_EQUAL(status, HDMI_CEC_IO_SUCCESS);
+
+    if (status == HDMI_CEC_IO_SUCCESS)
+    {
+
+        UT_LOG_INFO("Result HdmiCecGetPhysicalAddress(IN:handle:[0x%0X], OUT:physicalAddress:[%01x.%01x.%01x.%01x]) HDMI_CEC_STATUS:[%s]",
+                    gHandle, gPhysicalAddressBytes[3], gPhysicalAddressBytes[2], gPhysicalAddressBytes[1], gPhysicalAddressBytes[0],
+                    UT_Control_GetMapString(cecError_mapTable, status));
+    }
+    else
+    {
+        UT_LOG_ERROR("HdmiCecGetPhysicalAddress failed.");
+    }
 
     UT_LOG_INFO("Out %s\n", __FUNCTION__);
 }
@@ -718,12 +753,25 @@ void test_l3_hdmi_cec_hal_RemoveLogicalAddress(void)
 
     UT_ASSERT_NOT_EQUAL(logicalAddress, -1);
 
+    if (logicalAddress == -1)
+    {
+        UT_LOG_ERROR("Invalid logicalAddress.");
+        return;
+    }
+
     UT_LOG_INFO("Calling HdmiCecRemoveLogicalAddress(IN:handle:[0x%0X], IN:logicalAddress:[%d])", gHandle, logicalAddress);
     status = HdmiCecRemoveLogicalAddress(gHandle, logicalAddress);
     UT_LOG_INFO("Result HdmiCecRemoveLogicalAddress(IN:handle:[0x%0X], IN:logicalAddress:[%d]) HDMI_CEC_STATUS:[%s])", gHandle, logicalAddress, UT_Control_GetMapString(cecError_mapTable,status));
     UT_ASSERT_EQUAL(status, HDMI_CEC_IO_SUCCESS);
 
-    gLogicalAddress = -1;
+    if (status == HDMI_CEC_IO_SUCCESS)
+    {
+        gLogicalAddress = -1;
+    }
+    else
+    {
+        UT_LOG_ERROR("HdmiCecRemoveLogicalAddress failed. State not updated.");
+    }
 
     UT_LOG_INFO("Out %s\n", __FUNCTION__);
 }

--- a/src/test_l3_hdmi_cec_driver.c
+++ b/src/test_l3_hdmi_cec_driver.c
@@ -66,8 +66,6 @@
 #define TIMEOUT 5
 #define REPLY_TIMEOUT 5
 
-#define CEC_ASSERT UT_ASSERT
-
 #define HDMI_CEC_MAX_PAYLOAD 128
 #define HDMI_CEC_MAX_OSDNAME 15
 #define HDMI_CEC_KVP_SIZE 128
@@ -456,14 +454,14 @@ void test_l3_hdmi_cec_hal_Init(void)
     UT_LOG_INFO("Calling HdmiCecOpen(OUT:handle:[])");
     status = HdmiCecOpen(&gHandle);
     UT_LOG_INFO("Result HdmiCecOpen(OUT:handle:[0x%0X]) HDMI_CEC_STATUS:[%s]",gHandle, UT_Control_GetMapString(cecError_mapTable,status));
-    CEC_ASSERT(status == HDMI_CEC_IO_SUCCESS);
-    CEC_ASSERT(gHandle != 0);
+    UT_ASSERT_EQUAL(status, HDMI_CEC_IO_SUCCESS);
+    UT_ASSERT_NOT_EQUAL(gHandle, 0);
 
     // Step 2: Register the call back
     UT_LOG_INFO("Calling HdmiCecSetRxCallback(IN:handle:[0x%0X], IN:cbfunc:[0x%0X])",gHandle, onRxDataReceived);
     status = HdmiCecSetRxCallback(gHandle, onRxDataReceived,(void*)0xABABABAB);
     UT_LOG_INFO("Result HdmiCecSetRxCallback(IN:handle:[0x%0X], IN:cbfunc:[0x%0X]) HDMI_CEC_STATUS:[%s]",gHandle,onRxDataReceived, UT_Control_GetMapString(cecError_mapTable,status));
-    CEC_ASSERT(status == HDMI_CEC_IO_SUCCESS);
+    UT_ASSERT_EQUAL(status, HDMI_CEC_IO_SUCCESS);
 
     gPhysicalAddressBytes = (uint8_t*)&gPhysicalAddress;
 
@@ -472,7 +470,7 @@ void test_l3_hdmi_cec_hal_Init(void)
     UT_LOG_INFO("Result HdmiCecGetPhysicalAddress(IN:handle:[0x%0X], OUT:physicalAddress:[%01x.%01x.%01x.%01x]) HDMI_CEC_STATUS:[%s]", gHandle,
                                                   gPhysicalAddressBytes[3], gPhysicalAddressBytes[2], gPhysicalAddressBytes[1], gPhysicalAddressBytes[0],
                                                   UT_Control_GetMapString(cecError_mapTable,status));
-    CEC_ASSERT(status == HDMI_CEC_IO_SUCCESS);
+    UT_ASSERT_EQUAL(status, HDMI_CEC_IO_SUCCESS);
 
     if (gDeviceType == SOURCE)
     {
@@ -530,13 +528,13 @@ void test_l3_hdmi_cec_hal_AddLogicalAddress(void)
     UT_LOG_INFO("Calling HdmiCecAddLogicalAddress(IN:handle:[0x%0X], IN:logicalAddress:[%x]", gHandle, logicalAddress);
     status = HdmiCecAddLogicalAddress(gHandle, logicalAddress);
     UT_LOG_INFO("Result HdmiCecAddLogicalAddress (IN:handle:[0x%0X], IN:logicalAddress:[%x]) HDMI_CEC_STATUS[%s]",gHandle,logicalAddress,UT_Control_GetMapString(cecError_mapTable,status));
-    CEC_ASSERT(status == HDMI_CEC_IO_SUCCESS);
+    UT_ASSERT_EQUAL(status, HDMI_CEC_IO_SUCCESS);
 
     UT_LOG_INFO("Calling HdmiCecGetLogicalAddress(IN:handle:[0x%0X], OUT:logicalAddress:[])", gHandle);
     status = HdmiCecGetLogicalAddress(gHandle, &getLogicalAddress);
     UT_LOG_INFO("Result HdmiCecGetLogicalAddress(IN:handle:[0x%0X], OUT:logicalAddress:[%x]) HDMI_CEC_STATUS:[%s])", gHandle, getLogicalAddress, UT_Control_GetMapString(cecError_mapTable,status));
-    CEC_ASSERT(status == HDMI_CEC_IO_SUCCESS);
-    CEC_ASSERT(logicalAddress == getLogicalAddress);
+    UT_ASSERT_EQUAL(status, HDMI_CEC_IO_SUCCESS);
+    UT_ASSERT_EQUAL(logicalAddress, getLogicalAddress);
 
     gLogicalAddress = getLogicalAddress;
 
@@ -569,8 +567,8 @@ void test_l3_hdmi_cec_hal_GetLogicalAddress(void)
     UT_LOG_INFO("Calling HdmiCecGetLogicalAddress(IN:handle:[0x%0X], OUT:logicalAddress:[])", gHandle);
     status = HdmiCecGetLogicalAddress(gHandle, &logicalAddress);
     UT_LOG_INFO("Result HdmiCecGetLogicalAddress(IN:handle:[0x%0X], OUT:logicalAddress:[%x]) HDMI_CEC_STATUS:[%s])", gHandle, logicalAddress, UT_Control_GetMapString(cecError_mapTable,status));
-    CEC_ASSERT(status == HDMI_CEC_IO_SUCCESS);
-    CEC_ASSERT(logicalAddress >= 0 && logicalAddress <= 15);
+    UT_ASSERT_EQUAL(status, HDMI_CEC_IO_SUCCESS);
+    UT_ASSERT_TRUE(logicalAddress >= 0 && logicalAddress <= 15);
 
     gLogicalAddress = logicalAddress;
     UT_LOG_INFO("Out %s\n", __FUNCTION__);
@@ -605,7 +603,7 @@ void test_l3_hdmi_cec_hal_TransmitHdmiCecCommand(void) {
     const char* commandName;
     int32_t expectedDataLength;
 
-    CEC_ASSERT(sourceLogicalAddress != -1);
+    UT_ASSERT_NOT_EQUAL(sourceLogicalAddress, -1);
 
     // Reading inputs from the user or test framework
     UT_LOG_MENU_INFO("Enter a valid Destination Logical Address: ");
@@ -650,7 +648,7 @@ void test_l3_hdmi_cec_hal_TransmitHdmiCecCommand(void) {
     UT_LOG_INFO("Calling HdmiCecTx(IN:handle:[0x%0X], IN:buf:[%p], IN:len:[%d], OUT:result:[])", gHandle, buf, len);
     int32_t status = HdmiCecTx(gHandle, buf, len, &result);
     UT_LOG_INFO("Result HdmiCecTx(IN:handle:[0x%0X], IN:buf:[%p], IN:len:[%d], OUT:result:[%s]) HDMI_CEC_STATUS:[%s]", gHandle, buf, len, UT_Control_GetMapString(cecError_mapTable, result)? UT_Control_GetMapString(cecError_mapTable, result):"HDMI_CEC_IO_SENT_FAILED", UT_Control_GetMapString(cecError_mapTable,status));
-    CEC_ASSERT(status == HDMI_CEC_IO_SUCCESS || status == HDMI_CEC_IO_SENT_AND_ACKD || status == HDMI_CEC_IO_SENT_BUT_NOT_ACKD );
+    UT_ASSERT_TRUE(status == HDMI_CEC_IO_SUCCESS || status == HDMI_CEC_IO_SENT_AND_ACKD || status == HDMI_CEC_IO_SENT_BUT_NOT_ACKD );
 
     UT_LOG_INFO("Out %s\n", __FUNCTION__);
 }
@@ -682,7 +680,7 @@ void test_l3_hdmi_cec_hal_GetPhysicalAddress(void)
     UT_LOG_INFO("Result HdmiCecGetPhysicalAddress(IN:handle:[0x%0X], OUT:physicalAddress:[%01x.%01x.%01x.%01x]) HDMI_CEC_STATUS:[%s]", gHandle,
                                                   gPhysicalAddressBytes[3], gPhysicalAddressBytes[2], gPhysicalAddressBytes[1], gPhysicalAddressBytes[0],
                                                   UT_Control_GetMapString(cecError_mapTable,status));
-    CEC_ASSERT(status == HDMI_CEC_IO_SUCCESS);
+    UT_ASSERT_EQUAL(status, HDMI_CEC_IO_SUCCESS);
 
     UT_LOG_INFO("Out %s\n", __FUNCTION__);
 }
@@ -718,12 +716,12 @@ void test_l3_hdmi_cec_hal_RemoveLogicalAddress(void)
         return;
     }
 
-    CEC_ASSERT(logicalAddress != -1);
+    UT_ASSERT_NOT_EQUAL(logicalAddress, -1);
 
     UT_LOG_INFO("Calling HdmiCecRemoveLogicalAddress(IN:handle:[0x%0X], IN:logicalAddress:[%d])", gHandle, logicalAddress);
     status = HdmiCecRemoveLogicalAddress(gHandle, logicalAddress);
     UT_LOG_INFO("Result HdmiCecRemoveLogicalAddress(IN:handle:[0x%0X], IN:logicalAddress:[%d]) HDMI_CEC_STATUS:[%s])", gHandle, logicalAddress, UT_Control_GetMapString(cecError_mapTable,status));
-    CEC_ASSERT(status == HDMI_CEC_IO_SUCCESS);
+    UT_ASSERT_EQUAL(status, HDMI_CEC_IO_SUCCESS);
 
     gLogicalAddress = -1;
 
@@ -753,7 +751,7 @@ void test_l3_hdmi_cec_hal_Close(void)
     UT_LOG_INFO("Calling HdmiCecClose(IN:handle:[0x%0X])", gHandle);
     status = HdmiCecClose(gHandle);
     UT_LOG_INFO("Result HdmiCecClose(IN:handle:[0x%0X]) HDMI_CEC_STATUS:[%s]", gHandle, UT_Control_GetMapString(cecError_mapTable,status));
-    CEC_ASSERT(status == HDMI_CEC_IO_SUCCESS);
+    UT_ASSERT_EQUAL(status, HDMI_CEC_IO_SUCCESS);
     gHandle = 0;
 
     UT_LOG_INFO("Out %s\n", __FUNCTION__);

--- a/src/test_l3_hdmi_cec_driver.c
+++ b/src/test_l3_hdmi_cec_driver.c
@@ -66,6 +66,8 @@
 #define TIMEOUT 5
 #define REPLY_TIMEOUT 5
 
+#define CEC_ASSERT UT_ASSERT
+
 #define HDMI_CEC_MAX_PAYLOAD 128
 #define HDMI_CEC_MAX_OSDNAME 15
 #define HDMI_CEC_KVP_SIZE 128
@@ -454,14 +456,14 @@ void test_l3_hdmi_cec_hal_Init(void)
     UT_LOG_INFO("Calling HdmiCecOpen(OUT:handle:[])");
     status = HdmiCecOpen(&gHandle);
     UT_LOG_INFO("Result HdmiCecOpen(OUT:handle:[0x%0X]) HDMI_CEC_STATUS:[%s]",gHandle, UT_Control_GetMapString(cecError_mapTable,status));
-    assert(status == HDMI_CEC_IO_SUCCESS);
-    assert(gHandle != 0);
+    CEC_ASSERT(status == HDMI_CEC_IO_SUCCESS);
+    CEC_ASSERT(gHandle != 0);
 
     // Step 2: Register the call back
     UT_LOG_INFO("Calling HdmiCecSetRxCallback(IN:handle:[0x%0X], IN:cbfunc:[0x%0X])",gHandle, onRxDataReceived);
     status = HdmiCecSetRxCallback(gHandle, onRxDataReceived,(void*)0xABABABAB);
     UT_LOG_INFO("Result HdmiCecSetRxCallback(IN:handle:[0x%0X], IN:cbfunc:[0x%0X]) HDMI_CEC_STATUS:[%s]",gHandle,onRxDataReceived, UT_Control_GetMapString(cecError_mapTable,status));
-    assert(status == HDMI_CEC_IO_SUCCESS);
+    CEC_ASSERT(status == HDMI_CEC_IO_SUCCESS);
 
     gPhysicalAddressBytes = (uint8_t*)&gPhysicalAddress;
 
@@ -470,7 +472,7 @@ void test_l3_hdmi_cec_hal_Init(void)
     UT_LOG_INFO("Result HdmiCecGetPhysicalAddress(IN:handle:[0x%0X], OUT:physicalAddress:[%01x.%01x.%01x.%01x]) HDMI_CEC_STATUS:[%s]", gHandle,
                                                   gPhysicalAddressBytes[3], gPhysicalAddressBytes[2], gPhysicalAddressBytes[1], gPhysicalAddressBytes[0],
                                                   UT_Control_GetMapString(cecError_mapTable,status));
-    assert(status == HDMI_CEC_IO_SUCCESS);
+    CEC_ASSERT(status == HDMI_CEC_IO_SUCCESS);
 
     if (gDeviceType == SOURCE)
     {
@@ -528,13 +530,13 @@ void test_l3_hdmi_cec_hal_AddLogicalAddress(void)
     UT_LOG_INFO("Calling HdmiCecAddLogicalAddress(IN:handle:[0x%0X], IN:logicalAddress:[%x]", gHandle, logicalAddress);
     status = HdmiCecAddLogicalAddress(gHandle, logicalAddress);
     UT_LOG_INFO("Result HdmiCecAddLogicalAddress (IN:handle:[0x%0X], IN:logicalAddress:[%x]) HDMI_CEC_STATUS[%s]",gHandle,logicalAddress,UT_Control_GetMapString(cecError_mapTable,status));
-    assert(status == HDMI_CEC_IO_SUCCESS);
+    CEC_ASSERT(status == HDMI_CEC_IO_SUCCESS);
 
     UT_LOG_INFO("Calling HdmiCecGetLogicalAddress(IN:handle:[0x%0X], OUT:logicalAddress:[])", gHandle);
     status = HdmiCecGetLogicalAddress(gHandle, &getLogicalAddress);
     UT_LOG_INFO("Result HdmiCecGetLogicalAddress(IN:handle:[0x%0X], OUT:logicalAddress:[%x]) HDMI_CEC_STATUS:[%s])", gHandle, getLogicalAddress, UT_Control_GetMapString(cecError_mapTable,status));
-    assert(status == HDMI_CEC_IO_SUCCESS);
-    assert(logicalAddress == getLogicalAddress);
+    CEC_ASSERT(status == HDMI_CEC_IO_SUCCESS);
+    CEC_ASSERT(logicalAddress == getLogicalAddress);
 
     gLogicalAddress = getLogicalAddress;
 
@@ -567,8 +569,8 @@ void test_l3_hdmi_cec_hal_GetLogicalAddress(void)
     UT_LOG_INFO("Calling HdmiCecGetLogicalAddress(IN:handle:[0x%0X], OUT:logicalAddress:[])", gHandle);
     status = HdmiCecGetLogicalAddress(gHandle, &logicalAddress);
     UT_LOG_INFO("Result HdmiCecGetLogicalAddress(IN:handle:[0x%0X], OUT:logicalAddress:[%x]) HDMI_CEC_STATUS:[%s])", gHandle, logicalAddress, UT_Control_GetMapString(cecError_mapTable,status));
-    assert(status == HDMI_CEC_IO_SUCCESS);
-    assert(logicalAddress >= 0 && logicalAddress <= 15);
+    CEC_ASSERT(status == HDMI_CEC_IO_SUCCESS);
+    CEC_ASSERT(logicalAddress >= 0 && logicalAddress <= 15);
 
     gLogicalAddress = logicalAddress;
     UT_LOG_INFO("Out %s\n", __FUNCTION__);
@@ -603,7 +605,7 @@ void test_l3_hdmi_cec_hal_TransmitHdmiCecCommand(void) {
     const char* commandName;
     int32_t expectedDataLength;
 
-    assert(sourceLogicalAddress != -1);
+    CEC_ASSERT(sourceLogicalAddress != -1);
 
     // Reading inputs from the user or test framework
     UT_LOG_MENU_INFO("Enter a valid Destination Logical Address: ");
@@ -648,7 +650,7 @@ void test_l3_hdmi_cec_hal_TransmitHdmiCecCommand(void) {
     UT_LOG_INFO("Calling HdmiCecTx(IN:handle:[0x%0X], IN:buf:[%p], IN:len:[%d], OUT:result:[])", gHandle, buf, len);
     int32_t status = HdmiCecTx(gHandle, buf, len, &result);
     UT_LOG_INFO("Result HdmiCecTx(IN:handle:[0x%0X], IN:buf:[%p], IN:len:[%d], OUT:result:[%s]) HDMI_CEC_STATUS:[%s]", gHandle, buf, len, UT_Control_GetMapString(cecError_mapTable, result)? UT_Control_GetMapString(cecError_mapTable, result):"HDMI_CEC_IO_SENT_FAILED", UT_Control_GetMapString(cecError_mapTable,status));
-    assert(status == HDMI_CEC_IO_SUCCESS || status == HDMI_CEC_IO_SENT_AND_ACKD || status == HDMI_CEC_IO_SENT_BUT_NOT_ACKD );
+    CEC_ASSERT(status == HDMI_CEC_IO_SUCCESS || status == HDMI_CEC_IO_SENT_AND_ACKD || status == HDMI_CEC_IO_SENT_BUT_NOT_ACKD );
 
     UT_LOG_INFO("Out %s\n", __FUNCTION__);
 }
@@ -680,7 +682,7 @@ void test_l3_hdmi_cec_hal_GetPhysicalAddress(void)
     UT_LOG_INFO("Result HdmiCecGetPhysicalAddress(IN:handle:[0x%0X], OUT:physicalAddress:[%01x.%01x.%01x.%01x]) HDMI_CEC_STATUS:[%s]", gHandle,
                                                   gPhysicalAddressBytes[3], gPhysicalAddressBytes[2], gPhysicalAddressBytes[1], gPhysicalAddressBytes[0],
                                                   UT_Control_GetMapString(cecError_mapTable,status));
-    assert(status == HDMI_CEC_IO_SUCCESS);
+    CEC_ASSERT(status == HDMI_CEC_IO_SUCCESS);
 
     UT_LOG_INFO("Out %s\n", __FUNCTION__);
 }
@@ -716,12 +718,12 @@ void test_l3_hdmi_cec_hal_RemoveLogicalAddress(void)
         return;
     }
 
-    assert(logicalAddress != -1);
+    CEC_ASSERT(logicalAddress != -1);
 
     UT_LOG_INFO("Calling HdmiCecRemoveLogicalAddress(IN:handle:[0x%0X], IN:logicalAddress:[%d])", gHandle, logicalAddress);
     status = HdmiCecRemoveLogicalAddress(gHandle, logicalAddress);
     UT_LOG_INFO("Result HdmiCecRemoveLogicalAddress(IN:handle:[0x%0X], IN:logicalAddress:[%d]) HDMI_CEC_STATUS:[%s])", gHandle, logicalAddress, UT_Control_GetMapString(cecError_mapTable,status));
-    assert(status == HDMI_CEC_IO_SUCCESS);
+    CEC_ASSERT(status == HDMI_CEC_IO_SUCCESS);
 
     gLogicalAddress = -1;
 
@@ -751,7 +753,7 @@ void test_l3_hdmi_cec_hal_Close(void)
     UT_LOG_INFO("Calling HdmiCecClose(IN:handle:[0x%0X])", gHandle);
     status = HdmiCecClose(gHandle);
     UT_LOG_INFO("Result HdmiCecClose(IN:handle:[0x%0X]) HDMI_CEC_STATUS:[%s]", gHandle, UT_Control_GetMapString(cecError_mapTable,status));
-    assert(status == HDMI_CEC_IO_SUCCESS);
+    CEC_ASSERT(status == HDMI_CEC_IO_SUCCESS);
     gHandle = 0;
 
     UT_LOG_INFO("Out %s\n", __FUNCTION__);


### PR DESCRIPTION
HDMI CEC L3 is using assert function which terminates the test if the validation fails.

https://github.com/search?q=repo%3Ardkcentral%2Frdk-halif-test-hdmi_cec%20assert&type=code

Solution:

Use UT_ASSERT instead of assert function.